### PR TITLE
feat: add schedules and more finetuning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test lint clean install-tools dev help
+.PHONY: build build-go build-ts run test lint clean install-tools dev help
 .DEFAULT_GOAL := help
 
 # Variables

--- a/internal/database/migrations/002_task_schedules.sql
+++ b/internal/database/migrations/002_task_schedules.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- Create task_schedules table
+CREATE TABLE IF NOT EXISTS task_schedules (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    family_id TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    task_type TEXT NOT NULL CHECK (task_type IN ('todo', 'chore', 'appointment')),
+    assigned_to TEXT,
+    days_of_week TEXT NOT NULL, -- JSON array: ["tuesday", "thursday"] 
+    time_of_day TEXT, -- HH:MM format, optional specific time
+    priority INTEGER DEFAULT 0,
+    points INTEGER DEFAULT 0,
+    active BOOLEAN DEFAULT true,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (family_id) REFERENCES families(id) ON DELETE CASCADE,
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (assigned_to) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Create task_queue table for reliable task generation
+CREATE TABLE IF NOT EXISTS task_queue (
+    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    queue_type TEXT NOT NULL, -- 'generate_scheduled_tasks'
+    payload TEXT NOT NULL, -- JSON with schedule_id, target_date, etc.
+    status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts INTEGER DEFAULT 0,
+    max_attempts INTEGER DEFAULT 3,
+    scheduled_for DATETIME NOT NULL, -- when to process this queue item
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    processed_at DATETIME,
+    error_message TEXT
+);
+
+-- Add schedule_id to existing tasks table to link generated tasks back to their schedule
+ALTER TABLE tasks ADD COLUMN schedule_id TEXT REFERENCES task_schedules(id) ON DELETE SET NULL;
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_task_schedules_family_active ON task_schedules(family_id, active);
+CREATE INDEX IF NOT EXISTS idx_task_queue_status_scheduled ON task_queue(status, scheduled_for);
+CREATE INDEX IF NOT EXISTS idx_tasks_schedule_id ON tasks(schedule_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_tasks_schedule_id;
+DROP INDEX IF EXISTS idx_task_queue_status_scheduled;
+DROP INDEX IF NOT EXISTS idx_task_schedules_family_active;
+ALTER TABLE tasks DROP COLUMN schedule_id;
+DROP TABLE IF EXISTS task_queue;
+DROP TABLE IF EXISTS task_schedules;

--- a/internal/handlers/api/schedule.go
+++ b/internal/handlers/api/schedule.go
@@ -1,0 +1,498 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"famstack/internal/database"
+	"famstack/internal/services"
+)
+
+type ScheduleHandler struct {
+	db           *database.DB
+	queueService *services.QueueService
+}
+
+func NewScheduleHandler(db *database.DB) *ScheduleHandler {
+	return &ScheduleHandler{
+		db:           db,
+		queueService: services.NewQueueService(db),
+	}
+}
+
+type TaskSchedule struct {
+	ID          string   `json:"id"`
+	FamilyID    string   `json:"family_id"`
+	CreatedBy   string   `json:"created_by"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	TaskType    string   `json:"task_type"`
+	AssignedTo  *string  `json:"assigned_to"`
+	DaysOfWeek  []string `json:"days_of_week"`
+	TimeOfDay   *string  `json:"time_of_day"`
+	Priority    int      `json:"priority"`
+	Points      int      `json:"points"`
+	Active      bool     `json:"active"`
+	CreatedAt   string   `json:"created_at"`
+}
+
+type CreateScheduleRequest struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	TaskType    string   `json:"task_type"`
+	AssignedTo  *string  `json:"assigned_to"`
+	DaysOfWeek  []string `json:"days_of_week"`
+	TimeOfDay   *string  `json:"time_of_day"`
+	Priority    int      `json:"priority"`
+	Points      int      `json:"points"`
+	FamilyID    string   `json:"family_id"`
+}
+
+type QueueItem struct {
+	ID           string  `json:"id"`
+	QueueType    string  `json:"queue_type"`
+	Payload      string  `json:"payload"`
+	Status       string  `json:"status"`
+	Attempts     int     `json:"attempts"`
+	MaxAttempts  int     `json:"max_attempts"`
+	ScheduledFor string  `json:"scheduled_for"`
+	CreatedAt    string  `json:"created_at"`
+	ProcessedAt  *string `json:"processed_at"`
+	ErrorMessage *string `json:"error_message"`
+}
+
+// extractIDFromPath extracts the ID from the URL path
+func extractIDFromPath(path, prefix string) string {
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	remaining := strings.TrimPrefix(path, prefix)
+	if remaining == "" {
+		return ""
+	}
+	// Remove leading slash
+	remaining = strings.TrimPrefix(remaining, "/")
+	// Get first segment (ID)
+	parts := strings.Split(remaining, "/")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return ""
+}
+
+func (h *ScheduleHandler) ListSchedules(w http.ResponseWriter, r *http.Request) {
+	familyID := r.URL.Query().Get("family_id")
+	if familyID == "" {
+		familyID = "fam1" // Default family for now
+	}
+
+	query := `
+		SELECT id, family_id, created_by, title, description, task_type, 
+			   assigned_to, days_of_week, time_of_day, priority, points, active, created_at
+		FROM task_schedules 
+		WHERE family_id = ? AND active = true
+		ORDER BY created_at DESC
+	`
+
+	rows, err := h.db.Query(query, familyID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to query schedules: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	schedules := make([]TaskSchedule, 0)
+	for rows.Next() {
+		var schedule TaskSchedule
+		var assignedTo sql.NullString
+		var timeOfDay sql.NullString
+		var daysOfWeekJSON string
+
+		scanErr := rows.Scan(
+			&schedule.ID,
+			&schedule.FamilyID,
+			&schedule.CreatedBy,
+			&schedule.Title,
+			&schedule.Description,
+			&schedule.TaskType,
+			&assignedTo,
+			&daysOfWeekJSON,
+			&timeOfDay,
+			&schedule.Priority,
+			&schedule.Points,
+			&schedule.Active,
+			&schedule.CreatedAt,
+		)
+		if scanErr != nil {
+			http.Error(w, fmt.Sprintf("Failed to scan schedule: %v", scanErr), http.StatusInternalServerError)
+			return
+		}
+
+		// Handle nullable fields
+		if assignedTo.Valid {
+			schedule.AssignedTo = &assignedTo.String
+		}
+		if timeOfDay.Valid {
+			schedule.TimeOfDay = &timeOfDay.String
+		}
+
+		// Parse days of week JSON
+		err = json.Unmarshal([]byte(daysOfWeekJSON), &schedule.DaysOfWeek)
+		if err != nil {
+			log.Printf("Failed to parse days_of_week for schedule %s: %v", schedule.ID, err)
+			schedule.DaysOfWeek = []string{}
+		}
+
+		schedules = append(schedules, schedule)
+	}
+
+	if err = rows.Err(); err != nil {
+		http.Error(w, fmt.Sprintf("Row iteration error: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(schedules); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (h *ScheduleHandler) CreateSchedule(w http.ResponseWriter, r *http.Request) {
+	var req CreateScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Validate required fields
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+	if req.TaskType == "" {
+		http.Error(w, "Task type is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.DaysOfWeek) == 0 {
+		http.Error(w, "At least one day of the week is required", http.StatusBadRequest)
+		return
+	}
+	if req.FamilyID == "" {
+		req.FamilyID = "fam1" // Default family
+	}
+
+	// Validate days of week
+	validDays := map[string]bool{
+		"monday": true, "tuesday": true, "wednesday": true, "thursday": true,
+		"friday": true, "saturday": true, "sunday": true,
+	}
+	for _, day := range req.DaysOfWeek {
+		if !validDays[strings.ToLower(day)] {
+			http.Error(w, fmt.Sprintf("Invalid day of week: %s", day), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Convert days of week to JSON
+	daysOfWeekJSON, err := json.Marshal(req.DaysOfWeek)
+	if err != nil {
+		http.Error(w, "Failed to encode days of week", http.StatusInternalServerError)
+		return
+	}
+
+	// Handle assigned_to value
+	var assignedToValue interface{}
+	if req.AssignedTo != nil && *req.AssignedTo != "" {
+		assignedToValue = *req.AssignedTo
+	} else {
+		assignedToValue = nil
+	}
+
+	// Handle time_of_day value
+	var timeOfDayValue interface{}
+	if req.TimeOfDay != nil && *req.TimeOfDay != "" {
+		timeOfDayValue = *req.TimeOfDay
+	} else {
+		timeOfDayValue = nil
+	}
+
+	// Insert into database
+	query := `
+		INSERT INTO task_schedules (family_id, created_by, title, description, task_type,
+								   assigned_to, days_of_week, time_of_day, priority, points)
+		VALUES (?, 'user1', ?, ?, ?, ?, ?, ?, ?, ?) 
+		RETURNING id, created_at
+	`
+
+	var newID, createdAt string
+	err = h.db.QueryRow(query,
+		req.FamilyID,
+		req.Title,
+		req.Description,
+		req.TaskType,
+		assignedToValue,
+		string(daysOfWeekJSON),
+		timeOfDayValue,
+		req.Priority,
+		req.Points,
+	).Scan(&newID, &createdAt)
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create schedule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Create the response schedule object
+	schedule := TaskSchedule{
+		ID:          newID,
+		FamilyID:    req.FamilyID,
+		CreatedBy:   "user1", // TODO: Get from auth context
+		Title:       req.Title,
+		Description: req.Description,
+		TaskType:    req.TaskType,
+		AssignedTo:  req.AssignedTo,
+		DaysOfWeek:  req.DaysOfWeek,
+		TimeOfDay:   req.TimeOfDay,
+		Priority:    req.Priority,
+		Points:      req.Points,
+		Active:      true,
+		CreatedAt:   createdAt,
+	}
+
+	// Queue initial task generation for the next 14 days
+	err = h.queueService.QueueTaskGeneration(newID)
+	if err != nil {
+		log.Printf("Failed to queue task generation for schedule %s: %v", newID, err)
+		// Don't fail the request, just log the error
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(schedule); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (h *ScheduleHandler) GetSchedule(w http.ResponseWriter, r *http.Request) {
+	scheduleID := extractIDFromPath(r.URL.Path, "/api/v1/schedules")
+
+	query := `
+		SELECT id, family_id, created_by, title, description, task_type,
+			   assigned_to, days_of_week, time_of_day, priority, points, active, created_at
+		FROM task_schedules WHERE id = ?
+	`
+
+	var schedule TaskSchedule
+	var assignedTo sql.NullString
+	var timeOfDay sql.NullString
+	var daysOfWeekJSON string
+
+	err := h.db.QueryRow(query, scheduleID).Scan(
+		&schedule.ID,
+		&schedule.FamilyID,
+		&schedule.CreatedBy,
+		&schedule.Title,
+		&schedule.Description,
+		&schedule.TaskType,
+		&assignedTo,
+		&daysOfWeekJSON,
+		&timeOfDay,
+		&schedule.Priority,
+		&schedule.Points,
+		&schedule.Active,
+		&schedule.CreatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Schedule not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, fmt.Sprintf("Failed to get schedule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Handle nullable fields
+	if assignedTo.Valid {
+		schedule.AssignedTo = &assignedTo.String
+	}
+	if timeOfDay.Valid {
+		schedule.TimeOfDay = &timeOfDay.String
+	}
+
+	// Parse days of week JSON
+	err = json.Unmarshal([]byte(daysOfWeekJSON), &schedule.DaysOfWeek)
+	if err != nil {
+		log.Printf("Failed to parse days_of_week for schedule %s: %v", schedule.ID, err)
+		schedule.DaysOfWeek = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(schedule); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (h *ScheduleHandler) UpdateSchedule(w http.ResponseWriter, r *http.Request) {
+	scheduleID := extractIDFromPath(r.URL.Path, "/api/v1/schedules")
+
+	var updates map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Build dynamic update query
+	setParts := []string{}
+	args := []interface{}{}
+
+	for field, value := range updates {
+		switch field {
+		case "title", "description", "task_type", "priority", "points":
+			setParts = append(setParts, fmt.Sprintf("%s = ?", field))
+			args = append(args, value)
+		case "assigned_to":
+			setParts = append(setParts, "assigned_to = ?")
+			if value == nil || value == "" {
+				args = append(args, nil)
+			} else {
+				args = append(args, value)
+			}
+		case "time_of_day":
+			setParts = append(setParts, "time_of_day = ?")
+			if value == nil || value == "" {
+				args = append(args, nil)
+			} else {
+				args = append(args, value)
+			}
+		case "days_of_week":
+			daysJSON, err := json.Marshal(value)
+			if err != nil {
+				http.Error(w, "Invalid days_of_week format", http.StatusBadRequest)
+				return
+			}
+			setParts = append(setParts, "days_of_week = ?")
+			args = append(args, string(daysJSON))
+		case "active":
+			setParts = append(setParts, "active = ?")
+			args = append(args, value)
+		}
+	}
+
+	if len(setParts) == 0 {
+		http.Error(w, "No valid fields to update", http.StatusBadRequest)
+		return
+	}
+
+	args = append(args, scheduleID)
+	query := fmt.Sprintf("UPDATE task_schedules SET %s WHERE id = ?", strings.Join(setParts, ", "))
+
+	result, err := h.db.Exec(query, args...)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to update schedule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		http.Error(w, "Failed to check operation result", http.StatusInternalServerError)
+		return
+	}
+	if rowsAffected == 0 {
+		http.Error(w, "Schedule not found", http.StatusNotFound)
+		return
+	}
+
+	// If the schedule was updated, re-queue task generation
+	err = h.queueService.QueueTaskGenerationUpdate(scheduleID)
+	if err != nil {
+		log.Printf("Failed to queue task generation after update for schedule %s: %v", scheduleID, err)
+	}
+
+	// Fetch and return the updated schedule
+	query = `
+		SELECT id, family_id, created_by, title, description, task_type,
+			   assigned_to, days_of_week, time_of_day, priority, points, active, created_at
+		FROM task_schedules WHERE id = ?
+	`
+
+	var schedule TaskSchedule
+	var assignedTo sql.NullString
+	var timeOfDay sql.NullString
+	var daysOfWeekJSON string
+
+	err = h.db.QueryRow(query, scheduleID).Scan(
+		&schedule.ID,
+		&schedule.FamilyID,
+		&schedule.CreatedBy,
+		&schedule.Title,
+		&schedule.Description,
+		&schedule.TaskType,
+		&assignedTo,
+		&daysOfWeekJSON,
+		&timeOfDay,
+		&schedule.Priority,
+		&schedule.Points,
+		&schedule.Active,
+		&schedule.CreatedAt,
+	)
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to fetch updated schedule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Handle nullable fields
+	if assignedTo.Valid {
+		schedule.AssignedTo = &assignedTo.String
+	}
+	if timeOfDay.Valid {
+		schedule.TimeOfDay = &timeOfDay.String
+	}
+
+	// Parse days of week JSON
+	err = json.Unmarshal([]byte(daysOfWeekJSON), &schedule.DaysOfWeek)
+	if err != nil {
+		log.Printf("Failed to parse days_of_week for schedule %s: %v", schedule.ID, err)
+		schedule.DaysOfWeek = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(schedule); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func (h *ScheduleHandler) DeleteSchedule(w http.ResponseWriter, r *http.Request) {
+	scheduleID := extractIDFromPath(r.URL.Path, "/api/v1/schedules")
+
+	// Soft delete by setting active = false
+	query := "UPDATE task_schedules SET active = false WHERE id = ?"
+	result, err := h.db.Exec(query, scheduleID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to delete schedule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		http.Error(w, "Failed to check operation result", http.StatusInternalServerError)
+		return
+	}
+	if rowsAffected == 0 {
+		http.Error(w, "Schedule not found", http.StatusNotFound)
+		return
+	}
+
+	// Remove from queue since it's deleted
+	err = h.queueService.RemoveScheduleFromQueue(scheduleID)
+	if err != nil {
+		log.Printf("Failed to remove schedule from queue after deletion for schedule %s: %v", scheduleID, err)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/handlers/pages.go
+++ b/internal/handlers/pages.go
@@ -59,6 +59,8 @@ func (h *PageHandler) getPageTypeFromPath(urlPath string) string {
 	switch urlPath {
 	case "/tasks", "/":
 		return "tasks"
+	case "/schedules":
+		return "schedules"
 	case "/family/setup", "/family":
 		return "family"
 	default:
@@ -76,6 +78,9 @@ func (h *PageHandler) getPageTemplate(pageType string) (string, PageData) {
 	switch pageType {
 	case "tasks":
 		baseData.PageTitle = "Daily Tasks - FamStack"
+		return "web/templates/app.html.tmpl", baseData
+	case "schedules":
+		baseData.PageTitle = "Schedules - FamStack"
 		return "web/templates/app.html.tmpl", baseData
 	case "family":
 		baseData.PageTitle = "Family Setup - FamStack"

--- a/internal/services/queue.go
+++ b/internal/services/queue.go
@@ -1,0 +1,92 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"famstack/internal/database"
+)
+
+type QueueService struct {
+	db *database.DB
+}
+
+func NewQueueService(db *database.DB) *QueueService {
+	return &QueueService{
+		db: db,
+	}
+}
+
+// QueueTaskGeneration queues task generation for a schedule over the next 14 days
+func (qs *QueueService) QueueTaskGeneration(scheduleID string) error {
+	now := time.Now()
+
+	// Generate queue items for the next 14 days
+	for i := range 14 {
+		targetDate := now.AddDate(0, 0, i)
+		payload := map[string]any{
+			"schedule_id": scheduleID,
+			"target_date": targetDate.Format("2006-01-02"),
+		}
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %v", err)
+		}
+
+		// Schedule processing for midnight of the target date minus 1 day
+		scheduledFor := targetDate.AddDate(0, 0, -1).Truncate(24 * time.Hour)
+		if scheduledFor.Before(now) {
+			scheduledFor = now // Process immediately if it's in the past
+		}
+
+		query := `
+			INSERT OR IGNORE INTO task_queue (queue_type, payload, scheduled_for)
+			VALUES ('generate_scheduled_tasks', ?, ?)
+		`
+
+		_, err = qs.db.Exec(query, string(payloadJSON), scheduledFor.Format("2006-01-02 15:04:05"))
+		if err != nil {
+			return fmt.Errorf("failed to insert queue item: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// QueueTaskGenerationUpdate removes old queue items and queues new ones for a schedule
+func (qs *QueueService) QueueTaskGenerationUpdate(scheduleID string) error {
+	// Remove existing unprocessed queue items for this schedule
+	deleteQuery := `
+		DELETE FROM task_queue 
+		WHERE queue_type = 'generate_scheduled_tasks' 
+		AND status = 'pending'
+		AND json_extract(payload, '$.schedule_id') = ?
+	`
+
+	_, err := qs.db.Exec(deleteQuery, scheduleID)
+	if err != nil {
+		return fmt.Errorf("failed to delete existing queue items: %v", err)
+	}
+
+	// Queue new items
+	return qs.QueueTaskGeneration(scheduleID)
+}
+
+// RemoveScheduleFromQueue removes all queue items for a deleted schedule
+func (qs *QueueService) RemoveScheduleFromQueue(scheduleID string) error {
+	deleteQuery := `
+		DELETE FROM task_queue 
+		WHERE queue_type = 'generate_scheduled_tasks' 
+		AND status = 'pending'
+		AND json_extract(payload, '$.schedule_id') = ?
+	`
+
+	_, err := qs.db.Exec(deleteQuery, scheduleID)
+	if err != nil {
+		return fmt.Errorf("failed to remove schedule from queue: %v", err)
+	}
+
+	return nil
+}

--- a/internal/workers/queue_worker.go
+++ b/internal/workers/queue_worker.go
@@ -1,0 +1,333 @@
+package workers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"famstack/internal/database"
+)
+
+type QueueWorker struct {
+	db       *database.DB
+	interval time.Duration
+	stopCh   chan struct{}
+}
+
+type QueuePayload struct {
+	ScheduleID string `json:"schedule_id"`
+	TargetDate string `json:"target_date"`
+}
+
+type TaskSchedule struct {
+	ID          string
+	FamilyID    string
+	CreatedBy   string
+	Title       string
+	Description string
+	TaskType    string
+	AssignedTo  *string
+	DaysOfWeek  []string
+	TimeOfDay   *string
+	Priority    int
+	Points      int
+}
+
+func NewQueueWorker(db *database.DB, interval time.Duration) *QueueWorker {
+	return &QueueWorker{
+		db:       db,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+func (qw *QueueWorker) Start() {
+	log.Printf("Queue worker started with interval: %v", qw.interval)
+
+	ticker := time.NewTicker(qw.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			qw.processQueue()
+		case <-qw.stopCh:
+			log.Println("Queue worker stopped")
+			return
+		}
+	}
+}
+
+func (qw *QueueWorker) Stop() {
+	close(qw.stopCh)
+}
+
+func (qw *QueueWorker) processQueue() {
+	// Find pending queue items that are ready to be processed
+	query := `
+		SELECT id, payload, attempts
+		FROM task_queue 
+		WHERE status = 'pending' 
+		AND scheduled_for <= datetime('now')
+		AND queue_type = 'generate_scheduled_tasks'
+		ORDER BY scheduled_for ASC
+		LIMIT 10
+	`
+
+	rows, err := qw.db.Query(query)
+	if err != nil {
+		log.Printf("Failed to query queue items: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var queueID, payloadJSON string
+		var attempts int
+
+		err := rows.Scan(&queueID, &payloadJSON, &attempts)
+		if err != nil {
+			log.Printf("Failed to scan queue item: %v", err)
+			continue
+		}
+
+		qw.processQueueItem(queueID, payloadJSON, attempts)
+	}
+}
+
+func (qw *QueueWorker) processQueueItem(queueID, payloadJSON string, attempts int) {
+	log.Printf("Processing queue item %s (attempt %d)", queueID, attempts+1)
+
+	// Mark as processing
+	_, err := qw.db.Exec(
+		"UPDATE task_queue SET status = 'processing', attempts = attempts + 1 WHERE id = ?",
+		queueID,
+	)
+	if err != nil {
+		log.Printf("Failed to mark queue item as processing: %v", err)
+		return
+	}
+
+	// Parse payload
+	var payload QueuePayload
+	err = json.Unmarshal([]byte(payloadJSON), &payload)
+	if err != nil {
+		qw.markQueueItemFailed(queueID, fmt.Sprintf("Invalid payload JSON: %v", err))
+		return
+	}
+
+	// Generate the task
+	err = qw.generateScheduledTask(payload.ScheduleID, payload.TargetDate)
+	if err != nil {
+		// Check if we should retry
+		maxAttempts := 3
+		if attempts+1 >= maxAttempts {
+			qw.markQueueItemFailed(queueID, err.Error())
+		} else {
+			// Reset to pending for retry
+			qw.markQueueItemPending(queueID, err.Error())
+		}
+		return
+	}
+
+	// Mark as completed
+	_, err = qw.db.Exec(
+		"UPDATE task_queue SET status = 'completed', processed_at = datetime('now') WHERE id = ?",
+		queueID,
+	)
+	if err != nil {
+		log.Printf("Failed to mark queue item as completed: %v", err)
+	}
+
+	log.Printf("Successfully processed queue item %s", queueID)
+}
+
+func (qw *QueueWorker) markQueueItemFailed(queueID, errorMsg string) {
+	_, err := qw.db.Exec(
+		"UPDATE task_queue SET status = 'failed', error_message = ?, processed_at = datetime('now') WHERE id = ?",
+		errorMsg, queueID,
+	)
+	if err != nil {
+		log.Printf("Failed to mark queue item as failed: %v", err)
+	}
+	log.Printf("Queue item %s marked as failed: %s", queueID, errorMsg)
+}
+
+func (qw *QueueWorker) markQueueItemPending(queueID, errorMsg string) {
+	_, err := qw.db.Exec(
+		"UPDATE task_queue SET status = 'pending', error_message = ? WHERE id = ?",
+		errorMsg, queueID,
+	)
+	if err != nil {
+		log.Printf("Failed to mark queue item as pending for retry: %v", err)
+	}
+	log.Printf("Queue item %s marked as pending for retry: %s", queueID, errorMsg)
+}
+
+func (qw *QueueWorker) generateScheduledTask(scheduleID, targetDateStr string) error {
+	// Parse target date
+	targetDate, err := time.Parse("2006-01-02", targetDateStr)
+	if err != nil {
+		return fmt.Errorf("invalid target date format: %v", err)
+	}
+
+	// Get the schedule
+	schedule, err := qw.getTaskSchedule(scheduleID)
+	if err != nil {
+		return fmt.Errorf("failed to get schedule: %v", err)
+	}
+
+	// Check if this day of week matches the schedule
+	weekday := targetDate.Weekday().String()
+	dayMatches := false
+	for _, day := range schedule.DaysOfWeek {
+		if weekday == day {
+			dayMatches = true
+			break
+		}
+	}
+
+	if !dayMatches {
+		log.Printf("Target date %s (%s) doesn't match schedule days: %v", targetDateStr, weekday, schedule.DaysOfWeek)
+		return nil // Not an error, just skip this day
+	}
+
+	// Check if task already exists for this schedule and date
+	existingTask, err := qw.checkExistingTask(scheduleID, targetDateStr)
+	if err != nil {
+		return fmt.Errorf("failed to check existing task: %v", err)
+	}
+	if existingTask {
+		log.Printf("Task already exists for schedule %s on %s", scheduleID, targetDateStr)
+		return nil // Task already exists, skip
+	}
+
+	// Create the task
+	err = qw.createTaskFromSchedule(schedule, targetDate)
+	if err != nil {
+		return fmt.Errorf("failed to create task: %v", err)
+	}
+
+	log.Printf("Created task for schedule %s on %s", scheduleID, targetDateStr)
+	return nil
+}
+
+func (qw *QueueWorker) getTaskSchedule(scheduleID string) (*TaskSchedule, error) {
+	query := `
+		SELECT id, family_id, created_by, title, description, task_type,
+			   assigned_to, days_of_week, time_of_day, priority, points
+		FROM task_schedules 
+		WHERE id = ? AND active = true
+	`
+
+	var schedule TaskSchedule
+	var assignedTo sql.NullString
+	var timeOfDay sql.NullString
+	var daysOfWeekJSON string
+
+	err := qw.db.QueryRow(query, scheduleID).Scan(
+		&schedule.ID,
+		&schedule.FamilyID,
+		&schedule.CreatedBy,
+		&schedule.Title,
+		&schedule.Description,
+		&schedule.TaskType,
+		&assignedTo,
+		&daysOfWeekJSON,
+		&timeOfDay,
+		&schedule.Priority,
+		&schedule.Points,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle nullable fields
+	if assignedTo.Valid {
+		schedule.AssignedTo = &assignedTo.String
+	}
+	if timeOfDay.Valid {
+		schedule.TimeOfDay = &timeOfDay.String
+	}
+
+	// Parse days of week JSON
+	err = json.Unmarshal([]byte(daysOfWeekJSON), &schedule.DaysOfWeek)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse days_of_week: %v", err)
+	}
+
+	return &schedule, nil
+}
+
+func (qw *QueueWorker) checkExistingTask(scheduleID, targetDate string) (bool, error) {
+	query := `
+		SELECT COUNT(*) FROM tasks 
+		WHERE schedule_id = ? 
+		AND DATE(created_at) = ?
+	`
+
+	var count int
+	err := qw.db.QueryRow(query, scheduleID, targetDate).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
+func (qw *QueueWorker) createTaskFromSchedule(schedule *TaskSchedule, targetDate time.Time) error {
+	// Handle assigned_to value
+	var assignedToValue interface{}
+	if schedule.AssignedTo != nil {
+		assignedToValue = *schedule.AssignedTo
+	} else {
+		assignedToValue = nil
+	}
+
+	// Create due date with optional time
+	var dueDate *time.Time
+	if schedule.TimeOfDay != nil {
+		// Parse time and set it on the target date
+		timeStr := *schedule.TimeOfDay
+		if timePart, err := time.Parse("15:04", timeStr); err == nil {
+			dueDateWithTime := time.Date(
+				targetDate.Year(), targetDate.Month(), targetDate.Day(),
+				timePart.Hour(), timePart.Minute(), 0, 0, targetDate.Location(),
+			)
+			dueDate = &dueDateWithTime
+		}
+	}
+
+	var dueDateValue interface{}
+	if dueDate != nil {
+		dueDateValue = dueDate.Format("2006-01-02 15:04:05")
+	} else {
+		dueDateValue = nil
+	}
+
+	query := `
+		INSERT INTO tasks (family_id, assigned_to, title, description, task_type,
+						  status, priority, points, due_date, created_by, schedule_id)
+		VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+		RETURNING id
+	`
+
+	var newID string
+	err := qw.db.QueryRow(query,
+		schedule.FamilyID,
+		assignedToValue,
+		schedule.Title,
+		schedule.Description,
+		schedule.TaskType,
+		schedule.Priority,
+		schedule.Points,
+		dueDateValue,
+		schedule.CreatedBy,
+		schedule.ID,
+	).Scan(&newID)
+
+	return err
+}

--- a/web/components/.eslintrc.json
+++ b/web/components/.eslintrc.json
@@ -12,7 +12,8 @@
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "no-console": "warn",
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "no-undef": "off"
   },
   "env": {
     "browser": true,

--- a/web/components/src/families/family-member-modal.ts
+++ b/web/components/src/families/family-member-modal.ts
@@ -1,0 +1,243 @@
+import { ComponentConfig } from '../common/types.js';
+import { FamilyMember, CreateFamilyMemberRequest } from './family-service.js';
+
+export type FamilyMemberFormData = Omit<CreateFamilyMemberRequest, 'family_id'>;
+
+export interface FamilyMemberModalOptions {
+  onSave: (data: FamilyMemberFormData, memberId?: string) => Promise<void>;
+  onCancel?: () => void;
+}
+
+export class FamilyMemberModal {
+  private element!: HTMLElement;
+  private backdrop!: HTMLElement;
+  private currentMember: FamilyMember | undefined;
+  private isSubmitting: boolean = false;
+  private onSave: (data: FamilyMemberFormData, memberId?: string) => Promise<void>;
+  private onCancel: (() => void) | undefined;
+  private boundHandleClick?: (e: Event) => void;
+  private boundHandleSubmit?: (e: Event) => void;
+
+  constructor(container: HTMLElement, config: ComponentConfig, options: FamilyMemberModalOptions) {
+    this.onSave = options.onSave;
+    this.onCancel = options.onCancel;
+    
+    this.createElement(container);
+    this.attachEventListeners();
+  }
+
+  private createElement(container: HTMLElement): void {
+    // Create modal
+    this.element = document.createElement('div');
+    this.element.className = 'modal';
+    this.element.id = 'family-member-modal';
+    this.element.style.display = 'none';
+    this.element.innerHTML = this.getModalHTML();
+
+    // Create backdrop
+    this.backdrop = document.createElement('div');
+    this.backdrop.className = 'modal-backdrop';
+    this.backdrop.style.display = 'none';
+
+    container.appendChild(this.element);
+    container.appendChild(this.backdrop);
+  }
+
+  private getModalHTML(): string {
+    return `
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="modal-title">Add Family Member</h2>
+          <button class="modal-close" data-action="close-modal" type="button">×</button>
+        </div>
+        <form id="family-member-form">
+          <input type="hidden" id="member-id" name="id">
+          
+          <div class="form-group">
+            <label for="member-name">Name *</label>
+            <input type="text" id="member-name" name="name" required 
+                   placeholder="Enter member name">
+          </div>
+
+          <div class="form-group">
+            <label for="member-email">Email</label>
+            <input type="email" id="member-email" name="email"
+                   placeholder="Enter email (optional)">
+          </div>
+
+          <div class="form-group">
+            <label for="member-role">Role *</label>
+            <select id="member-role" name="role" required>
+              <option value="">Select role</option>
+              <option value="parent">Parent</option>
+              <option value="child">Child</option>
+            </select>
+          </div>
+
+          <div class="modal-actions">
+            <button type="button" class="btn btn-secondary" data-action="close-modal">Cancel</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">Add Member</button>
+          </div>
+        </form>
+      </div>
+    `;
+  }
+
+  private attachEventListeners(): void {
+    this.boundHandleClick = this.handleClick.bind(this);
+    this.boundHandleSubmit = this.handleSubmit.bind(this);
+    
+    this.element.addEventListener('click', this.boundHandleClick);
+    this.element.addEventListener('submit', this.boundHandleSubmit);
+  }
+
+  public showCreate(): void {
+    this.currentMember = undefined;
+    
+    const title = this.element.querySelector('#modal-title') as HTMLElement;
+    const submitBtn = this.element.querySelector('#submit-btn') as HTMLButtonElement;
+    
+    title.textContent = 'Add Family Member';
+    submitBtn.textContent = 'Add Member';
+    
+    this.resetForm();
+    this.show();
+  }
+
+  public showEdit(member: FamilyMember): void {
+    this.currentMember = member;
+    
+    const title = this.element.querySelector('#modal-title') as HTMLElement;
+    const submitBtn = this.element.querySelector('#submit-btn') as HTMLButtonElement;
+    
+    title.textContent = 'Edit Family Member';
+    submitBtn.textContent = 'Update Member';
+    
+    this.populateForm(member);
+    this.show();
+  }
+
+  private show(): void {
+    this.element.style.display = 'flex';
+    this.backdrop.style.display = 'block';
+    
+    const nameInput = this.element.querySelector('#member-name') as HTMLInputElement;
+    nameInput?.focus();
+  }
+
+  public hide(): void {
+    this.element.style.display = 'none';
+    this.backdrop.style.display = 'none';
+    this.resetForm();
+  }
+
+  private resetForm(): void {
+    const form = this.element.querySelector('#family-member-form') as HTMLFormElement;
+    form.reset();
+    
+    // Clear any error messages
+    const errors = form.querySelectorAll('.field-error');
+    errors.forEach(error => error.remove());
+  }
+
+  private populateForm(member: FamilyMember): void {
+    const form = this.element.querySelector('#family-member-form') as HTMLFormElement;
+    
+    (form.querySelector('#member-id') as HTMLInputElement).value = member.id;
+    (form.querySelector('#member-name') as HTMLInputElement).value = member.name;
+    (form.querySelector('#member-email') as HTMLInputElement).value = member.email || '';
+    (form.querySelector('#member-role') as HTMLSelectElement).value = member.role;
+  }
+
+  private handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const action = target.getAttribute('data-action');
+    
+    if (action === 'close-modal') {
+      e.preventDefault();
+      this.hide();
+      this.onCancel?.();
+    }
+  }
+
+  private handleSubmit(e: Event): void {
+    e.preventDefault();
+    if (this.isSubmitting) return;
+    
+    const form = e.target as HTMLFormElement;
+    this.handleFormSubmit(form);
+  }
+
+  private async handleFormSubmit(form: HTMLFormElement): Promise<void> {
+    if (this.isSubmitting) return;
+    
+    this.isSubmitting = true;
+    
+    try {
+      const formData = this.getFormData(form);
+      const memberId = this.currentMember?.id;
+      
+      await this.onSave(formData, memberId);
+      this.hide();
+    } catch (error) {
+      this.showFormError(form, error instanceof Error ? error.message : 'Failed to save family member');
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  private getFormData(form: HTMLFormElement): FamilyMemberFormData {
+    const formData = new FormData(form);
+    
+    const name = formData.get('name') as string;
+    const email = formData.get('email') as string;
+    const role = formData.get('role') as string;
+    
+    if (!name.trim()) {
+      throw new Error('Name is required');
+    }
+    
+    if (!role) {
+      throw new Error('Role is required');
+    }
+    
+    return {
+      name: name.trim(),
+      email: email.trim() || '',
+      role: role
+    };
+  }
+
+  private showFormError(form: HTMLFormElement, message: string): void {
+    // Clear existing errors
+    const existingErrors = form.querySelectorAll('.field-error');
+    existingErrors.forEach(error => error.remove());
+    
+    // Add new error
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'field-error form-error-general';
+    errorDiv.textContent = message;
+    errorDiv.style.cssText = `
+      color: #e53e3e;
+      font-size: 0.875rem;
+      margin-top: 0.5rem;
+      padding: 0.5rem;
+      background: #fed7d7;
+      border-radius: 4px;
+    `;
+    
+    form.appendChild(errorDiv);
+  }
+
+  public destroy(): void {
+    if (this.boundHandleClick) {
+      this.element.removeEventListener('click', this.boundHandleClick);
+    }
+    if (this.boundHandleSubmit) {
+      this.element.removeEventListener('submit', this.boundHandleSubmit);
+    }
+    
+    this.element.remove();
+    this.backdrop.remove();
+  }
+}

--- a/web/components/src/families/family-page.ts
+++ b/web/components/src/families/family-page.ts
@@ -7,8 +7,6 @@ import { ComponentConfig } from '../common/types.js';
  */
 export class FamilyPage extends BasePage {
   private familyMembers?: FamilyMembers;
-  private boundShowModal?: () => void;
-  private boundHideModal?: () => void;
   private boundHandleSuccess?: (e: Event) => void;
 
   constructor(container: HTMLElement, config: ComponentConfig) {
@@ -106,8 +104,6 @@ export class FamilyPage extends BasePage {
 
   private setupEventHandlers(): void {
     // Bind methods to preserve `this` context
-    this.boundShowModal = this.showAddMemberModal.bind(this);
-    this.boundHideModal = this.hideAddMemberModal.bind(this);
     this.boundHandleSuccess = this.handleFormSuccess.bind(this);
 
     // Add event listeners

--- a/web/components/src/families/family-selector.ts
+++ b/web/components/src/families/family-selector.ts
@@ -1,13 +1,11 @@
 import { ComponentConfig } from '../common/types.js';
 
 export class FamilySelector {
-  private config: ComponentConfig;
   private container: HTMLElement;
   private selectedUsers: Set<string> = new Set();
 
-  constructor(container: HTMLElement, config: ComponentConfig) {
+  constructor(container: HTMLElement, _config: ComponentConfig) {
     this.container = container;
-    this.config = config;
     this.init();
   }
 
@@ -44,7 +42,6 @@ export class FamilySelector {
     if (!userId) return;
 
     const isSelected = this.selectedUsers.has(userId);
-
     if (isSelected) {
       this.selectedUsers.delete(userId);
       selectorItem.classList.remove('selected');

--- a/web/components/src/families/family-service.ts
+++ b/web/components/src/families/family-service.ts
@@ -1,0 +1,201 @@
+import { ComponentConfig } from '../common/types.js';
+
+export interface FamilyMember {
+  id: string;
+  family_id: string;
+  name: string;
+  email: string;
+  role: string;
+  created_at: string;
+}
+
+export interface CreateFamilyMemberRequest {
+  name: string;
+  email: string;
+  role: string;
+  family_id?: string;
+}
+
+export interface Family {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface CreateFamilyRequest {
+  name: string;
+}
+
+export class FamilyService {
+  private config: ComponentConfig;
+
+  constructor(config: ComponentConfig) {
+    this.config = config;
+  }
+
+  // Family Management
+  async listFamilies(): Promise<Family[]> {
+    const response = await fetch(`${this.config.apiBaseUrl}/families`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch families: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async createFamily(familyData: CreateFamilyRequest): Promise<Family> {
+    const response = await fetch(`${this.config.apiBaseUrl}/families`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(familyData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `Failed to create family: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getFamily(familyId: string): Promise<Family> {
+    const response = await fetch(`${this.config.apiBaseUrl}/families/${familyId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch family: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async updateFamily(familyId: string, updates: Partial<CreateFamilyRequest>): Promise<Family> {
+    const response = await fetch(`${this.config.apiBaseUrl}/families/${familyId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(updates),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update family: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async deleteFamily(familyId: string): Promise<void> {
+    const response = await fetch(`${this.config.apiBaseUrl}/families/${familyId}`, {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete family: ${response.statusText}`);
+    }
+  }
+
+  // Family Member Management
+  async listFamilyMembers(familyId?: string): Promise<FamilyMember[]> {
+    const url = familyId 
+      ? `${this.config.apiBaseUrl}/users?family_id=${familyId}`
+      : `${this.config.apiBaseUrl}/users`;
+      
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch family members: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async createFamilyMember(memberData: CreateFamilyMemberRequest): Promise<FamilyMember> {
+    const response = await fetch(`${this.config.apiBaseUrl}/users`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(memberData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `Failed to create family member: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getFamilyMember(memberId: string): Promise<FamilyMember> {
+    const response = await fetch(`${this.config.apiBaseUrl}/users/${memberId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch family member: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async updateFamilyMember(memberId: string, updates: Partial<CreateFamilyMemberRequest>): Promise<FamilyMember> {
+    const response = await fetch(`${this.config.apiBaseUrl}/users/${memberId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(updates),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update family member: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async deleteFamilyMember(memberId: string): Promise<void> {
+    const response = await fetch(`${this.config.apiBaseUrl}/users/${memberId}`, {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete family member: ${response.statusText}`);
+    }
+  }
+}

--- a/web/components/src/index.css
+++ b/web/components/src/index.css
@@ -2,6 +2,7 @@
 @import './task-card.css';
 @import './task-list.css';
 @import './family-members.css';
+@import './schedules.css';
 
 /* Base styles for component integration */
 * {

--- a/web/components/src/main.ts
+++ b/web/components/src/main.ts
@@ -57,6 +57,16 @@ if (document.readyState === 'loading') {
   autoInit();
 }
 
+// Add a global debug function for manual testing
+(window as any).famstackDebug = {
+  testInit: () => {
+    autoInit();
+  },
+  getState: () => {
+    return 'Debug functions available';
+  }
+};
+
 // Handle HTMX page swaps (clean page component management)
 document.addEventListener('htmx:afterSwap', (event: any) => {
   const target = event.detail.target;

--- a/web/components/src/pages/page-factory.ts
+++ b/web/components/src/pages/page-factory.ts
@@ -2,6 +2,7 @@ import { ComponentConfig } from '../common/types.js';
 import { PageComponent } from './base-page.js';
 import { TasksPage } from '../tasks/tasks-page.js';
 import { FamilyPage } from '../families/family-page.js';
+import { SchedulesPage } from '../schedules/schedules-page.js';
 
 /**
  * Factory for creating page components based on page type
@@ -17,13 +18,15 @@ export class PageFactory {
         return new TasksPage(container, config);
       case 'family':
         return new FamilyPage(container, config);
+      case 'schedules':
+        return new SchedulesPage(container, config);
       default:
         return new TasksPage(container, config); // Default to tasks page
     }
   }
 
   static getAvailablePageTypes(): string[] {
-    return ['tasks', 'family'];
+    return ['tasks', 'family', 'schedules'];
   }
 }
 

--- a/web/components/src/pages/schedules.ts
+++ b/web/components/src/pages/schedules.ts
@@ -1,0 +1,33 @@
+import { ComponentConfig } from '../common/types.js';
+import { ScheduleList } from '../schedules/schedule-list.js';
+
+export class SchedulesPage {
+  private config: ComponentConfig;
+  private container: HTMLElement;
+  private scheduleList: ScheduleList | null = null;
+
+  constructor(config: ComponentConfig) {
+    this.config = config;
+    this.container = document.createElement('div');
+    this.container.className = 'schedules-page';
+  }
+
+  public render(targetContainer: HTMLElement): void {
+    targetContainer.appendChild(this.container);
+    
+    // Initialize the schedule list
+    this.scheduleList = new ScheduleList(this.container, this.config);
+  }
+
+  public destroy(): void {
+    if (this.scheduleList) {
+      this.scheduleList.destroy();
+      this.scheduleList = null;
+    }
+    this.container.remove();
+  }
+
+  public getElement(): HTMLElement {
+    return this.container;
+  }
+}

--- a/web/components/src/schedules.css
+++ b/web/components/src/schedules.css
@@ -1,0 +1,425 @@
+/* Schedule List Styles */
+.schedule-list-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.schedule-header {
+  display: flex;
+  justify-content: between;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid #e1e5e9;
+}
+
+.schedule-header h1 {
+  margin: 0;
+  color: #2d3748;
+  font-size: 2rem;
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 20px;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 60px 20px;
+  color: #718096;
+}
+
+.empty-state p {
+  margin: 10px 0;
+  font-size: 1.1rem;
+}
+
+.loading {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 40px;
+  color: #718096;
+}
+
+/* Schedule Card Styles */
+.schedule-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+  position: relative;
+}
+
+.schedule-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.schedule-card.active {
+  border-left: 4px solid #48bb78;
+}
+
+.schedule-card.inactive {
+  border-left: 4px solid #a0aec0;
+  opacity: 0.7;
+}
+
+.schedule-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.schedule-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #2d3748;
+  flex: 1;
+}
+
+.schedule-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.schedule-action-btn {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 16px;
+  transition: background-color 0.2s;
+}
+
+.schedule-action-btn:hover {
+  background: #f7fafc;
+}
+
+.schedule-description {
+  margin-bottom: 15px;
+  color: #4a5568;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.schedule-details {
+  margin-bottom: 15px;
+}
+
+.schedule-recurrence {
+  margin-bottom: 10px;
+}
+
+.schedule-days {
+  background: #edf2f7;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  color: #2d3748;
+  font-weight: 500;
+  display: inline-block;
+}
+
+.schedule-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.schedule-type {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.schedule-type.todo {
+  background: #bee3f8;
+  color: #2b6cb0;
+}
+
+.schedule-type.chore {
+  background: #c6f6d5;
+  color: #276749;
+}
+
+.schedule-type.appointment {
+  background: #fbb6ce;
+  color: #b83280;
+}
+
+.schedule-assignee {
+  color: #4a5568;
+  font-size: 0.9rem;
+}
+
+.schedule-points {
+  background: #fed7d7;
+  color: #c53030;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.schedule-status {
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;  /* Add this for consistent height */
+  display: inline-block;  /* Add this for better alignment */
+}
+
+.schedule-status.active {
+  background: #c6f6d5;
+  color: #276749;
+}
+
+.schedule-status.inactive {
+  background: #e2e8f0;
+  color: #718096;
+}
+
+/* Modal Styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 0;
+  max-width: 1200px;
+  width: 90vw;
+  min-width: 800px;
+  max-height: 95vh;
+  overflow-y: auto;
+  position: relative;
+  z-index: 1001;
+  margin: 20px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #2d3748;
+  font-size: 1.5rem;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #a0aec0;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-close:hover {
+  background: #f7fafc;
+  color: #4a5568;
+}
+
+.modal form {
+  padding: 24px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #e2e8f0;
+}
+
+/* Form Styles */
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.form-row-three {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 768px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+  
+  .form-row-three {
+    grid-template-columns: 1fr;
+  }
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #2d3748;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 16px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #3182ce;
+  box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.1);
+}
+
+.days-of-week {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.day-checkbox {
+  display: flex !important;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: normal !important;
+  margin-bottom: 0 !important;
+}
+
+.day-checkbox:hover {
+  background: #f7fafc;
+  border-color: #a0aec0;
+}
+
+.day-checkbox input[type="checkbox"] {
+  width: auto !important;
+  margin: 0;
+}
+
+.day-checkbox input[type="checkbox"]:checked + label,
+.day-checkbox:has(input[type="checkbox"]:checked) {
+  background: #3182ce;
+  color: white;
+  border-color: #3182ce;
+}
+
+/* Button Styles */
+.btn {
+  padding: 10px 16px;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+}
+
+.btn-primary {
+  background: #3182ce;
+  color: white;
+}
+
+.btn-primary:hover {
+  background: #2c5282;
+}
+
+.btn-secondary {
+  background: #e2e8f0;
+  color: #4a5568;
+}
+
+.btn-secondary:hover {
+  background: #cbd5e0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .schedule-list-container {
+    padding: 15px;
+  }
+  
+  .schedule-grid {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+  
+  .schedule-header {
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+  }
+  
+  .modal-content {
+    width: 98%;
+    margin: 5px;
+    max-height: 98vh;
+  }
+}

--- a/web/components/src/schedules/__tests__/schedule-card.test.ts
+++ b/web/components/src/schedules/__tests__/schedule-card.test.ts
@@ -1,0 +1,122 @@
+import { ScheduleCard } from '../schedule-card.js';
+import { TaskSchedule } from '../schedule-service.js';
+import { ComponentConfig } from '../../common/types.js';
+
+describe('ScheduleCard', () => {
+  let mockConfig: ComponentConfig;
+  let mockSchedule: TaskSchedule;
+  let onScheduleUpdate: jest.Mock;
+  let onScheduleDelete: jest.Mock;
+  let onScheduleToggle: jest.Mock;
+
+  beforeEach(() => {
+    mockConfig = {
+      apiBaseUrl: '/api/v1',
+      csrfToken: 'test-csrf-token'
+    };
+
+    mockSchedule = {
+      id: 'schedule1',
+      family_id: 'fam1',
+      created_by: 'user1',
+      title: 'Daily Exercise',
+      description: 'Morning workout routine',
+      task_type: 'chore',
+      assigned_to: 'user1',
+      days_of_week: ['monday', 'wednesday', 'friday'],
+      time_of_day: '07:00',
+      priority: 1,
+      points: 10,
+      active: true,
+      created_at: '2024-01-01T00:00:00Z'
+    };
+
+    onScheduleUpdate = jest.fn();
+    onScheduleDelete = jest.fn();
+    onScheduleToggle = jest.fn();
+  });
+
+  it('should create schedule card with correct content', () => {
+    const scheduleCard = new ScheduleCard(mockSchedule, mockConfig, {
+      onScheduleUpdate,
+      onScheduleDelete,
+      onScheduleToggle
+    });
+
+    const element = scheduleCard.getElement();
+
+    expect(element.getAttribute('data-schedule-id')).toBe('schedule1');
+    expect(element.classList.contains('schedule-card')).toBe(true);
+    expect(element.classList.contains('active')).toBe(true);
+    expect(element.textContent).toContain('Daily Exercise');
+    expect(element.textContent).toContain('Morning workout routine');
+  });
+
+  it('should show inactive class for inactive schedule', () => {
+    const inactiveSchedule = { ...mockSchedule, active: false };
+    const scheduleCard = new ScheduleCard(inactiveSchedule, mockConfig);
+
+    const element = scheduleCard.getElement();
+
+    expect(element.classList.contains('inactive')).toBe(true);
+    expect(element.classList.contains('active')).toBe(false);
+  });
+
+  it('should handle toggle action', () => {
+    const scheduleCard = new ScheduleCard(mockSchedule, mockConfig, {
+      onScheduleToggle
+    });
+
+    const element = scheduleCard.getElement();
+    const toggleButton = element.querySelector('[data-action="toggle"]') as HTMLElement;
+    
+    toggleButton.click();
+
+    expect(onScheduleToggle).toHaveBeenCalledWith('schedule1');
+  });
+
+  it('should handle delete action with confirmation', () => {
+    // Mock window.confirm
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+
+    const scheduleCard = new ScheduleCard(mockSchedule, mockConfig, {
+      onScheduleDelete
+    });
+
+    const element = scheduleCard.getElement();
+    const deleteButton = element.querySelector('[data-action="delete"]') as HTMLElement;
+    
+    deleteButton.click();
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to delete this schedule? This will not affect tasks already created from it.'
+    );
+    expect(onScheduleDelete).toHaveBeenCalledWith('schedule1');
+
+    // Restore original confirm
+    window.confirm = originalConfirm;
+  });
+
+  it('should format time correctly', () => {
+    const morningSchedule = { ...mockSchedule, time_of_day: '07:30' };
+    const scheduleCard = new ScheduleCard(morningSchedule, mockConfig);
+    const element = scheduleCard.getElement();
+    
+    expect(element.textContent).toContain('7:30 AM');
+  });
+
+  it('should update schedule content', () => {
+    const scheduleCard = new ScheduleCard(mockSchedule, mockConfig, {
+      onScheduleUpdate
+    });
+
+    const updatedSchedule = { ...mockSchedule, title: 'Updated Exercise', active: false };
+    scheduleCard.updateSchedule(updatedSchedule);
+
+    const element = scheduleCard.getElement();
+    expect(element.textContent).toContain('Updated Exercise');
+    expect(element.classList.contains('inactive')).toBe(true);
+    expect(onScheduleUpdate).toHaveBeenCalledWith(updatedSchedule);
+  });
+});

--- a/web/components/src/schedules/__tests__/schedule-list.test.ts
+++ b/web/components/src/schedules/__tests__/schedule-list.test.ts
@@ -1,0 +1,119 @@
+import { ScheduleList } from '../schedule-list.js';
+import { ScheduleService, TaskSchedule } from '../schedule-service.js';
+import { ComponentConfig } from '../../common/types.js';
+
+// Mock the ScheduleService
+jest.mock('../schedule-service.js');
+
+describe('ScheduleList', () => {
+  let mockConfig: ComponentConfig;
+  let container: HTMLElement;
+  let mockScheduleService: jest.Mocked<ScheduleService>;
+  let mockSchedules: TaskSchedule[];
+
+  beforeEach(() => {
+    mockConfig = {
+      apiBaseUrl: '/api/v1',
+      csrfToken: 'test-csrf-token'
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    mockSchedules = [
+      {
+        id: 'schedule1',
+        family_id: 'fam1',
+        created_by: 'user1',
+        title: 'Daily Exercise',
+        description: 'Morning workout',
+        task_type: 'chore',
+        assigned_to: 'user1',
+        days_of_week: ['monday', 'wednesday'],
+        time_of_day: '07:00',
+        priority: 1,
+        points: 10,
+        active: true,
+        created_at: '2024-01-01T00:00:00Z'
+      }
+    ];
+
+    mockScheduleService = {
+      listSchedules: jest.fn().mockResolvedValue(mockSchedules),
+      createSchedule: jest.fn(),
+      getSchedule: jest.fn(),
+      updateSchedule: jest.fn(),
+      deleteSchedule: jest.fn(),
+      toggleSchedule: jest.fn().mockResolvedValue({ active: false })
+    } as any;
+
+    (ScheduleService as jest.Mock).mockImplementation(() => mockScheduleService);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should initialize and load schedules', async () => {
+    const scheduleList = new ScheduleList(container, mockConfig);
+
+    expect(mockScheduleService.listSchedules).toHaveBeenCalled();
+    expect(container.querySelector('.schedule-grid')).toBeTruthy();
+  });
+
+  it('should show add schedule button', () => {
+    const scheduleList = new ScheduleList(container, mockConfig);
+    
+    const addButton = container.querySelector('[data-action="add-schedule"]') as HTMLElement;
+    expect(addButton).toBeTruthy();
+    expect(addButton.textContent?.trim()).toBe('+ Add Schedule');
+  });
+
+  it('should handle schedule toggle', async () => {
+    const scheduleList = new ScheduleList(container, mockConfig);
+    
+    // Wait for initialization
+    await new Promise(resolve => setTimeout(resolve, 0));
+    
+    // Find and trigger toggle on the first schedule
+    const toggleButton = container.querySelector('[data-action="toggle"]') as HTMLElement;
+    if (toggleButton) {
+      toggleButton.click();
+      
+      expect(mockScheduleService.toggleSchedule).toHaveBeenCalledWith('schedule1');
+    }
+  });
+
+  it('should handle schedule deletion with confirmation', async () => {
+    // Mock window.confirm
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+    mockScheduleService.deleteSchedule.mockResolvedValue();
+
+    const scheduleList = new ScheduleList(container, mockConfig);
+    
+    // Wait for initialization
+    await new Promise(resolve => setTimeout(resolve, 0));
+    
+    const deleteButton = container.querySelector('[data-action="delete"]') as HTMLElement;
+    if (deleteButton) {
+      deleteButton.click();
+      
+      expect(mockScheduleService.deleteSchedule).toHaveBeenCalledWith('schedule1');
+    }
+
+    // Restore original confirm
+    window.confirm = originalConfirm;
+  });
+
+  it('should show empty state when no schedules', async () => {
+    mockScheduleService.listSchedules.mockResolvedValue([]);
+    
+    const scheduleList = new ScheduleList(container, mockConfig);
+    
+    // Wait for async operations
+    await new Promise(resolve => setTimeout(resolve, 100));
+    
+    expect(container.textContent).toContain('No schedules created yet');
+  });
+});

--- a/web/components/src/schedules/__tests__/schedule-service.test.ts
+++ b/web/components/src/schedules/__tests__/schedule-service.test.ts
@@ -1,0 +1,144 @@
+import { ScheduleService, TaskSchedule, CreateScheduleRequest } from '../schedule-service.js';
+import { ComponentConfig } from '../../common/types.js';
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('ScheduleService', () => {
+  let scheduleService: ScheduleService;
+  let mockConfig: ComponentConfig;
+  
+  beforeEach(() => {
+    mockConfig = {
+      apiBaseUrl: '/api/v1',
+      csrfToken: 'test-csrf-token'
+    };
+    scheduleService = new ScheduleService(mockConfig);
+    (fetch as jest.Mock).mockClear();
+  });
+
+  describe('listSchedules', () => {
+    it('should fetch schedules successfully', async () => {
+      const mockSchedules: TaskSchedule[] = [
+        {
+          id: 'schedule1',
+          family_id: 'fam1',
+          created_by: 'user1',
+          title: 'Daily Exercise',
+          description: 'Morning workout routine',
+          task_type: 'chore',
+          assigned_to: 'user1',
+          days_of_week: ['monday', 'wednesday', 'friday'],
+          time_of_day: '07:00',
+          priority: 1,
+          points: 10,
+          active: true,
+          created_at: '2024-01-01T00:00:00Z'
+        }
+      ];
+
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSchedules
+      });
+
+      const result = await scheduleService.listSchedules();
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/schedules?family_id=fam1', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': 'test-csrf-token'
+        }
+      });
+      expect(result).toEqual(mockSchedules);
+    });
+
+    it('should throw error when fetch fails', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Internal Server Error'
+      });
+
+      await expect(scheduleService.listSchedules()).rejects.toThrow(
+        'Failed to fetch schedules: Internal Server Error'
+      );
+    });
+  });
+
+  describe('createSchedule', () => {
+    it('should create a new schedule', async () => {
+      const scheduleData: CreateScheduleRequest = {
+        title: 'Weekly Clean',
+        description: 'Clean the house',
+        task_type: 'chore',
+        assigned_to: 'user1',
+        days_of_week: ['saturday'],
+        time_of_day: '10:00',
+        priority: 2,
+        points: 15,
+        family_id: 'fam1'
+      };
+
+      const mockCreatedSchedule: TaskSchedule = {
+        id: 'schedule2',
+        ...scheduleData,
+        created_by: 'user1',
+        active: true,
+        created_at: '2024-01-01T00:00:00Z'
+      };
+
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockCreatedSchedule
+      });
+
+      const result = await scheduleService.createSchedule(scheduleData);
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/schedules', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': 'test-csrf-token'
+        },
+        body: JSON.stringify(scheduleData)
+      });
+      expect(result).toEqual(mockCreatedSchedule);
+    });
+  });
+
+  describe('toggleSchedule', () => {
+    it('should toggle schedule from active to inactive', async () => {
+      const mockSchedule: TaskSchedule = {
+        id: 'schedule1',
+        family_id: 'fam1',
+        created_by: 'user1',
+        title: 'Daily Exercise',
+        description: 'Morning workout routine',
+        task_type: 'chore',
+        assigned_to: 'user1',
+        days_of_week: ['monday'],
+        time_of_day: '07:00',
+        priority: 1,
+        points: 10,
+        active: true,
+        created_at: '2024-01-01T00:00:00Z'
+      };
+
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockSchedule
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ...mockSchedule, active: false })
+        });
+
+      const result = await scheduleService.toggleSchedule('schedule1');
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ active: false });
+    });
+  });
+});

--- a/web/components/src/schedules/__tests__/schedules-page.test.ts
+++ b/web/components/src/schedules/__tests__/schedules-page.test.ts
@@ -1,0 +1,65 @@
+import { SchedulesPage } from '../schedules-page.js';
+import { ScheduleList } from '../schedule-list.js';
+import { ComponentConfig } from '../../common/types.js';
+
+// Mock the ScheduleList
+jest.mock('../schedule-list.js');
+
+describe('SchedulesPage', () => {
+  let mockConfig: ComponentConfig;
+  let container: HTMLElement;
+  let mockScheduleList: jest.Mocked<ScheduleList>;
+
+  beforeEach(() => {
+    mockConfig = {
+      apiBaseUrl: '/api/v1',
+      csrfToken: 'test-csrf-token'
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    mockScheduleList = {
+      refresh: jest.fn(),
+      destroy: jest.fn()
+    } as any;
+
+    (ScheduleList as jest.Mock).mockImplementation(() => mockScheduleList);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should initialize page with correct structure', async () => {
+    const schedulesPage = new SchedulesPage(container, mockConfig);
+    await schedulesPage.init();
+
+    expect(container.querySelector('.schedules-page')).toBeTruthy();
+    expect(container.querySelector('.schedules-container')).toBeTruthy();
+    expect(ScheduleList).toHaveBeenCalledWith(
+      container.querySelector('#main-schedule-container'),
+      mockConfig
+    );
+  });
+
+  it('should refresh schedule list when refresh is called', async () => {
+    const schedulesPage = new SchedulesPage(container, mockConfig);
+    await schedulesPage.init();
+    
+    if (schedulesPage.refresh) {
+      await schedulesPage.refresh();
+      expect(mockScheduleList.refresh).toHaveBeenCalled();
+    }
+  });
+
+  it('should destroy schedule list when destroyed', async () => {
+    const schedulesPage = new SchedulesPage(container, mockConfig);
+    await schedulesPage.init();
+    
+    schedulesPage.destroy();
+    
+    expect(mockScheduleList.destroy).toHaveBeenCalled();
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/web/components/src/schedules/schedule-card.ts
+++ b/web/components/src/schedules/schedule-card.ts
@@ -1,0 +1,160 @@
+import { ComponentConfig } from '../common/types.js';
+import { TaskSchedule } from './schedule-service.js';
+
+export class ScheduleCard {
+  private schedule: TaskSchedule;
+  private element: HTMLElement;
+  private onScheduleUpdate?: (schedule: TaskSchedule) => void;
+  private onScheduleDelete?: (scheduleId: string) => void;
+  private onScheduleToggle?: (scheduleId: string) => void;
+  private onScheduleEdit?: (schedule: TaskSchedule) => void;
+  private boundHandleClick?: (e: Event) => void;
+
+  constructor(schedule: TaskSchedule, _config: ComponentConfig, options: {
+    onScheduleUpdate?: (schedule: TaskSchedule) => void;
+    onScheduleDelete?: (scheduleId: string) => void;
+    onScheduleToggle?: (scheduleId: string) => void;
+    onScheduleEdit?: (schedule: TaskSchedule) => void;
+  } = {}) {
+    this.schedule = schedule;
+    if (options.onScheduleUpdate) {
+      this.onScheduleUpdate = options.onScheduleUpdate;
+    }
+    if (options.onScheduleDelete) {
+      this.onScheduleDelete = options.onScheduleDelete;
+    }
+    if (options.onScheduleToggle) {
+      this.onScheduleToggle = options.onScheduleToggle;
+    }
+    if (options.onScheduleEdit) {
+      this.onScheduleEdit = options.onScheduleEdit;
+    }
+    this.element = this.createElement();
+    this.attachEventListeners();
+  }
+
+  private createElement(): HTMLElement {
+    const cardElement = document.createElement('div');
+    cardElement.className = `schedule-card ${this.schedule.active ? 'active' : 'inactive'}`;
+    cardElement.setAttribute('data-schedule-id', this.schedule.id);
+    cardElement.innerHTML = this.getCardHTML();
+    return cardElement;
+  }
+
+  private getCardHTML(): string {
+    const daysString = this.schedule.days_of_week.map(day => 
+      day.charAt(0).toUpperCase() + day.slice(1, 3)
+    ).join(', ');
+
+    const timeDisplay = this.schedule.time_of_day ? 
+      ` at ${this.formatTime(this.schedule.time_of_day)}` : '';
+
+    return `
+      <div class="schedule-header">
+        <div class="schedule-status ${this.schedule.active ? 'active' : 'inactive'}">
+          ${this.schedule.active ? 'Active' : 'Inactive'}
+        </div>
+        <div class="schedule-title">
+          ${this.schedule.title}
+        </div>
+        <div class="schedule-actions">
+          <button class="schedule-action-btn" data-action="toggle" 
+                  style="color: ${this.schedule.active ? 'orange' : 'green'};" 
+                  title="${this.schedule.active ? 'Deactivate' : 'Activate'}">
+            ${this.schedule.active ? '⏸' : '▶'}
+          </button>
+          <button class="schedule-action-btn" data-action="edit" style="color: blue;" title="Edit">
+            ✎
+          </button>
+          <button class="schedule-action-btn" data-action="delete" style="color: red;" title="Delete">
+            ×
+          </button>
+        </div>
+      </div>
+      ${this.schedule.description ? `
+        <div class="schedule-description">
+          ${this.schedule.description}
+        </div>
+      ` : ''}
+      <div class="schedule-details">
+        <div class="schedule-recurrence">
+          <span class="schedule-days">${daysString}${timeDisplay}</span>
+        </div>
+        <div class="schedule-meta">
+          <span class="schedule-type ${this.schedule.task_type}">${this.schedule.task_type}</span>
+          ${this.schedule.assigned_to ? `<span class="schedule-assignee">→ ${this.schedule.assigned_to}</span>` : '<span class="schedule-assignee">→ Unassigned</span>'}
+          ${this.schedule.points > 0 ? `<span class="schedule-points">${this.schedule.points} pts</span>` : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  private formatTime(time: string): string {
+    // Convert 24-hour time to 12-hour format
+    const parts = time.split(':').map(Number);
+    if (parts.length < 2) return time; // Return original if invalid format
+    
+    const hours = parts[0];
+    const minutes = parts[1];
+    if (hours === undefined || minutes === undefined) return time;
+    
+    const period = hours >= 12 ? 'PM' : 'AM';
+    const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+    return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}`;
+  }
+
+  private attachEventListeners(): void {
+    this.boundHandleClick = this.handleClick.bind(this);
+    this.element.addEventListener('click', this.boundHandleClick);
+  }
+
+  private handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const action = target.getAttribute('data-action');
+
+    if (action) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.handleAction(action);
+    }
+  }
+
+  private async handleAction(action: string): Promise<void> {
+    switch (action) {
+      case 'toggle':
+        this.onScheduleToggle?.(this.schedule.id);
+        break;
+      case 'edit':
+        this.onScheduleEdit?.(this.schedule);
+        break;
+      case 'delete':
+        if (confirm('Are you sure you want to delete this schedule? This will not affect tasks already created from it.')) {
+          this.onScheduleDelete?.(this.schedule.id);
+        }
+        break;
+    }
+  }
+
+
+  public updateSchedule(updatedSchedule: TaskSchedule): void {
+    this.schedule = updatedSchedule;
+    this.element.innerHTML = this.getCardHTML();
+    this.element.className = `schedule-card ${this.schedule.active ? 'active' : 'inactive'}`;
+    this.onScheduleUpdate?.(this.schedule);
+  }
+
+  public getElement(): HTMLElement {
+    return this.element;
+  }
+
+  public getSchedule(): TaskSchedule {
+    return this.schedule;
+  }
+
+  public destroy(): void {
+    if (this.boundHandleClick) {
+      this.element.removeEventListener('click', this.boundHandleClick);
+    }
+    this.element.remove();
+  }
+}

--- a/web/components/src/schedules/schedule-list.ts
+++ b/web/components/src/schedules/schedule-list.ts
@@ -1,0 +1,224 @@
+import { ComponentConfig } from '../common/types.js';
+import { TaskSchedule, ScheduleService } from './schedule-service.js';
+import { ScheduleCard } from './schedule-card.js';
+import { ScheduleModal, ScheduleFormData } from './schedule-modal.js';
+import { ComponentUtils } from '../common/component-utils.js';
+
+export class ScheduleList {
+  private config: ComponentConfig;
+  private container: HTMLElement;
+  private scheduleService: ScheduleService;
+  private scheduleCards: Map<string, ScheduleCard> = new Map();
+  private scheduleModal!: ScheduleModal;
+  private boundHandleClick?: (e: Event) => void;
+
+  constructor(container: HTMLElement, config: ComponentConfig) {
+    this.container = container;
+    this.config = config;
+    this.scheduleService = new ScheduleService(config);
+    this.init();
+  }
+
+  private init(): void {
+    this.container.className = 'schedule-list-container';
+    this.render();
+    this.setupEventListeners();
+    this.initializeModal();
+    this.loadSchedules();
+  }
+
+  private render(): void {
+    this.container.innerHTML = `
+      <div class="schedule-header">
+        <h1>Task Schedules</h1>
+        <button class="btn btn-primary" data-action="add-schedule">
+          + Add Schedule
+        </button>
+      </div>
+
+      <div class="schedule-grid" id="schedule-grid">
+        <div class="loading">Loading schedules...</div>
+      </div>
+    `;
+  }
+
+  private setupEventListeners(): void {
+    this.boundHandleClick = this.handleClick.bind(this);
+    this.container.addEventListener('click', this.boundHandleClick);
+  }
+
+  private initializeModal(): void {
+    this.scheduleModal = new ScheduleModal(this.container, this.config, {
+      onSave: this.handleModalSave.bind(this),
+      onCancel: () => {
+      }
+    });
+  }
+
+  private async handleModalSave(data: ScheduleFormData, scheduleId?: string): Promise<void> {
+    if (scheduleId) {
+      // Edit existing schedule
+      const updatedSchedule = await this.scheduleService.updateSchedule(scheduleId, data);
+      const scheduleCard = this.scheduleCards.get(scheduleId);
+      if (scheduleCard) {
+        scheduleCard.updateSchedule(updatedSchedule);
+      }
+      this.showSuccess('Schedule updated successfully!');
+    } else {
+      // Create new schedule
+      const scheduleData = { ...data, family_id: 'fam1' };
+      const newSchedule = await this.scheduleService.createSchedule(scheduleData);
+      this.addScheduleToList(newSchedule);
+      this.showSuccess('Schedule created successfully!');
+    }
+  }
+
+  private async loadSchedules(): Promise<void> {
+    try {
+      const schedules = await this.scheduleService.listSchedules();
+      this.renderSchedules(schedules);
+    } catch (error) {
+      this.showError('Failed to load schedules');
+    }
+  }
+
+  private renderSchedules(schedules: TaskSchedule[]): void {
+    const grid = this.container.querySelector('#schedule-grid') as HTMLElement;
+    
+    if (schedules.length === 0) {
+      grid.innerHTML = `
+        <div class="empty-state">
+          <p>No schedules created yet.</p>
+          <p>Create your first schedule to automatically generate recurring tasks.</p>
+        </div>
+      `;
+      return;
+    }
+
+    grid.innerHTML = '';
+    
+    // Clear existing cards
+    this.scheduleCards.forEach(card => card.destroy());
+    this.scheduleCards.clear();
+
+    // Create new cards
+    schedules.forEach(schedule => {
+      const scheduleCard = new ScheduleCard(schedule, this.config, {
+        onScheduleUpdate: this.handleScheduleUpdate.bind(this),
+        onScheduleDelete: this.handleScheduleDelete.bind(this),
+        onScheduleToggle: this.handleScheduleToggle.bind(this),
+        onScheduleEdit: this.handleScheduleEdit.bind(this)
+      });
+      
+      grid.appendChild(scheduleCard.getElement());
+      this.scheduleCards.set(schedule.id, scheduleCard);
+    });
+  }
+
+  private addScheduleToList(schedule: TaskSchedule): void {
+    const grid = this.container.querySelector('#schedule-grid') as HTMLElement;
+    const emptyState = grid.querySelector('.empty-state');
+    
+    if (emptyState) {
+      grid.innerHTML = '';
+    }
+
+    const scheduleCard = new ScheduleCard(schedule, this.config, {
+      onScheduleUpdate: this.handleScheduleUpdate.bind(this),
+      onScheduleDelete: this.handleScheduleDelete.bind(this),
+      onScheduleToggle: this.handleScheduleToggle.bind(this),
+      onScheduleEdit: this.handleScheduleEdit.bind(this)
+    });
+
+    grid.appendChild(scheduleCard.getElement());
+    this.scheduleCards.set(schedule.id, scheduleCard);
+  }
+
+  private handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const action = target.getAttribute('data-action');
+    
+    switch (action) {
+      case 'add-schedule':
+        this.scheduleModal.showCreate();
+        break;
+    }
+  }
+
+  private handleScheduleEdit(schedule: TaskSchedule): void {
+    this.scheduleModal.showEdit(schedule);
+  }
+
+  private async handleScheduleToggle(scheduleId: string): Promise<void> {
+    try {
+      const result = await this.scheduleService.toggleSchedule(scheduleId);
+      const scheduleCard = this.scheduleCards.get(scheduleId);
+      if (scheduleCard) {
+        const updatedSchedule = { ...scheduleCard.getSchedule(), active: result.active };
+        scheduleCard.updateSchedule(updatedSchedule);
+      }
+      this.showSuccess(`Schedule ${result.active ? 'activated' : 'deactivated'}`);
+    } catch (error) {
+      this.showError('Failed to toggle schedule');
+    }
+  }
+
+  private async handleScheduleDelete(scheduleId: string): Promise<void> {
+    try {
+      await this.scheduleService.deleteSchedule(scheduleId);
+      
+      const scheduleCard = this.scheduleCards.get(scheduleId);
+      if (scheduleCard) {
+        scheduleCard.destroy();
+        this.scheduleCards.delete(scheduleId);
+      }
+
+      // Show empty state if no schedules left
+      if (this.scheduleCards.size === 0) {
+        const grid = this.container.querySelector('#schedule-grid') as HTMLElement;
+        grid.innerHTML = `
+          <div class="empty-state">
+            <p>No schedules created yet.</p>
+            <p>Create your first schedule to automatically generate recurring tasks.</p>
+          </div>
+        `;
+      }
+
+      this.showSuccess('Schedule deleted successfully');
+    } catch (error) {
+      this.showError('Failed to delete schedule');
+    }
+  }
+
+  private handleScheduleUpdate(_: TaskSchedule): void {
+    // Handle any additional schedule update logic if needed
+  }
+
+  private showError(message: string): void {
+    ComponentUtils.showError(message);
+  }
+
+  private showSuccess(message: string): void {
+    ComponentUtils.showSuccess(message);
+  }
+
+  public async refresh(): Promise<void> {
+    await this.loadSchedules();
+  }
+
+  public destroy(): void {
+    // Clean up schedule cards
+    this.scheduleCards.forEach(card => card.destroy());
+    this.scheduleCards.clear();
+
+    // Clean up modal
+    if (this.scheduleModal) {
+      this.scheduleModal.destroy();
+    }
+
+    // Clean up event listeners
+    if (this.boundHandleClick) {
+      this.container.removeEventListener('click', this.boundHandleClick);
+    }
+  }
+}

--- a/web/components/src/schedules/schedule-modal.ts
+++ b/web/components/src/schedules/schedule-modal.ts
@@ -1,0 +1,320 @@
+import { ComponentConfig } from '../common/types.js';
+import { TaskSchedule, CreateScheduleRequest } from './schedule-service.js';
+
+export type ScheduleFormData = Omit<CreateScheduleRequest, 'family_id'>;
+
+export interface ScheduleModalOptions {
+  onSave: (data: ScheduleFormData, scheduleId?: string) => Promise<void>;
+  onCancel?: () => void;
+}
+
+export class ScheduleModal {
+  private element!: HTMLElement;
+  private backdrop!: HTMLElement;
+  private currentSchedule: TaskSchedule | undefined;
+  private isSubmitting: boolean = false;
+  private onSave: (data: ScheduleFormData, scheduleId?: string) => Promise<void>;
+  private onCancel: (() => void) | undefined;
+  private boundHandleClick?: (e: Event) => void;
+  private boundHandleSubmit?: (e: Event) => void;
+
+  constructor(container: HTMLElement, config: ComponentConfig, options: ScheduleModalOptions) {
+    this.onSave = options.onSave;
+    this.onCancel = options.onCancel;
+    
+    this.createElement(container);
+    this.attachEventListeners();
+    this.populateUserOptions();
+  }
+
+  private createElement(container: HTMLElement): void {
+    // Create modal
+    this.element = document.createElement('div');
+    this.element.className = 'modal';
+    this.element.id = 'schedule-modal';
+    this.element.style.display = 'none';
+    this.element.innerHTML = this.getModalHTML();
+
+    // Create backdrop
+    this.backdrop = document.createElement('div');
+    this.backdrop.className = 'modal-backdrop';
+    this.backdrop.style.display = 'none';
+
+    container.appendChild(this.element);
+    container.appendChild(this.backdrop);
+  }
+
+  private getModalHTML(): string {
+    return `
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="modal-title">Create New Schedule</h2>
+          <button class="modal-close" data-action="close-modal" type="button">×</button>
+        </div>
+        <form id="schedule-form">
+          <input type="hidden" id="schedule-id" name="id">
+          
+          <div class="form-group">
+            <label for="schedule-title">Title *</label>
+            <input type="text" id="schedule-title" name="title" required 
+                   placeholder="e.g., Take out trash, Do homework">
+          </div>
+
+          <div class="form-group">
+            <label for="schedule-description">Description</label>
+            <textarea id="schedule-description" name="description" rows="3"
+                      placeholder="Optional description..."></textarea>
+          </div>
+
+          <div class="form-row-three">
+            <div class="form-group">
+              <label for="schedule-type">Type *</label>
+              <select id="schedule-type" name="task_type" required>
+                <option value="chore">Chore</option>
+                <option value="todo">To-Do</option>
+                <option value="appointment">Appointment</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label for="schedule-assigned-to">Assigned To</label>
+              <select id="schedule-assigned-to" name="assigned_to">
+                <option value="">Unassigned</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label for="schedule-priority">Priority</label>
+              <select id="schedule-priority" name="priority">
+                <option value="0">Low</option>
+                <option value="1">Normal</option>
+                <option value="2">High</option>
+                <option value="3">Urgent</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label>Days of the Week *</label>
+            <div class="days-of-week">
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="monday"> Mon
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="tuesday"> Tue
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="wednesday"> Wed
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="thursday"> Thu
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="friday"> Fri
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="saturday"> Sat
+              </label>
+              <label class="day-checkbox">
+                <input type="checkbox" name="days_of_week" value="sunday"> Sun
+              </label>
+            </div>
+          </div>
+
+
+          <div class="modal-actions">
+            <button type="button" class="btn btn-secondary" data-action="close-modal">Cancel</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">Create Schedule</button>
+          </div>
+        </form>
+      </div>
+    `;
+  }
+
+  private attachEventListeners(): void {
+    this.boundHandleClick = this.handleClick.bind(this);
+    this.boundHandleSubmit = this.handleSubmit.bind(this);
+    
+    this.element.addEventListener('click', this.boundHandleClick);
+    this.element.addEventListener('submit', this.boundHandleSubmit);
+  }
+
+  private async populateUserOptions(): Promise<void> {
+    const select = this.element.querySelector('#schedule-assigned-to') as HTMLSelectElement;
+    if (select) {
+      // TODO: Replace with actual user fetching
+      select.innerHTML = `
+        <option value="">Unassigned</option>
+        <option value="user1">John Smith</option>
+        <option value="user2">Jane Smith</option>
+        <option value="user3">Bobby Smith</option>
+      `;
+    }
+  }
+
+  public showCreate(): void {
+    this.currentSchedule = undefined;
+    
+    const title = this.element.querySelector('#modal-title') as HTMLElement;
+    const submitBtn = this.element.querySelector('#submit-btn') as HTMLButtonElement;
+    
+    title.textContent = 'Create New Schedule';
+    submitBtn.textContent = 'Create Schedule';
+    
+    this.resetForm();
+    this.show();
+  }
+
+  public showEdit(schedule: TaskSchedule): void {
+    this.currentSchedule = schedule;
+    
+    const title = this.element.querySelector('#modal-title') as HTMLElement;
+    const submitBtn = this.element.querySelector('#submit-btn') as HTMLButtonElement;
+    
+    title.textContent = 'Edit Schedule';
+    submitBtn.textContent = 'Update Schedule';
+    
+    this.populateForm(schedule);
+    this.show();
+  }
+
+  private show(): void {
+    this.element.style.display = 'flex';
+    this.backdrop.style.display = 'block';
+    
+    const titleInput = this.element.querySelector('#schedule-title') as HTMLInputElement;
+    titleInput?.focus();
+  }
+
+  public hide(): void {
+    this.element.style.display = 'none';
+    this.backdrop.style.display = 'none';
+    this.resetForm();
+  }
+
+  private resetForm(): void {
+    const form = this.element.querySelector('#schedule-form') as HTMLFormElement;
+    form.reset();
+    
+    // Set default priority
+    const prioritySelect = form.querySelector('#schedule-priority') as HTMLSelectElement;
+    prioritySelect.value = '1';
+    
+    // Clear any error messages
+    const errors = form.querySelectorAll('.field-error');
+    errors.forEach(error => error.remove());
+  }
+
+  private populateForm(schedule: TaskSchedule): void {
+    const form = this.element.querySelector('#schedule-form') as HTMLFormElement;
+    
+    (form.querySelector('#schedule-id') as HTMLInputElement).value = schedule.id;
+    (form.querySelector('#schedule-title') as HTMLInputElement).value = schedule.title;
+    (form.querySelector('#schedule-description') as HTMLTextAreaElement).value = schedule.description || '';
+    (form.querySelector('#schedule-type') as HTMLSelectElement).value = schedule.task_type;
+    (form.querySelector('#schedule-assigned-to') as HTMLSelectElement).value = schedule.assigned_to || '';
+    (form.querySelector('#schedule-priority') as HTMLSelectElement).value = schedule.priority.toString();
+    
+    // Set checkboxes for days of the week
+    const dayCheckboxes = form.querySelectorAll('input[name="days_of_week"]') as NodeListOf<HTMLInputElement>;
+    dayCheckboxes.forEach(checkbox => {
+      checkbox.checked = schedule.days_of_week.includes(checkbox.value);
+    });
+  }
+
+  private handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const action = target.getAttribute('data-action');
+    
+    if (action === 'close-modal') {
+      e.preventDefault();
+      this.hide();
+      this.onCancel?.();
+    }
+  }
+
+  private handleSubmit(e: Event): void {
+    e.preventDefault();
+    if (this.isSubmitting) return;
+    
+    const form = e.target as HTMLFormElement;
+    this.handleFormSubmit(form);
+  }
+
+  private async handleFormSubmit(form: HTMLFormElement): Promise<void> {
+    if (this.isSubmitting) return;
+    
+    this.isSubmitting = true;
+    
+    try {
+      const formData = this.getFormData(form);
+      const scheduleId = this.currentSchedule?.id;
+      
+      await this.onSave(formData, scheduleId);
+      this.hide();
+    } catch (error) {
+      this.showFormError(form, error instanceof Error ? error.message : 'Failed to save schedule');
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  private getFormData(form: HTMLFormElement): ScheduleFormData {
+    const formData = new FormData(form);
+    
+    // Get selected days
+    const selectedDays: string[] = [];
+    const dayCheckboxes = form.querySelectorAll('input[name="days_of_week"]:checked') as NodeListOf<HTMLInputElement>;
+    dayCheckboxes.forEach(checkbox => {
+      selectedDays.push(checkbox.value);
+    });
+    
+    if (selectedDays.length === 0) {
+      throw new Error('Please select at least one day of the week');
+    }
+    
+    return {
+      title: formData.get('title') as string,
+      description: formData.get('description') as string || '',
+      task_type: formData.get('task_type') as 'todo' | 'chore' | 'appointment',
+      assigned_to: formData.get('assigned_to') as string || null,
+      days_of_week: selectedDays,
+      time_of_day: null,
+      priority: parseInt(formData.get('priority') as string),
+      points: 0
+    };
+  }
+
+  private showFormError(form: HTMLFormElement, message: string): void {
+    // Clear existing errors
+    const existingErrors = form.querySelectorAll('.field-error');
+    existingErrors.forEach(error => error.remove());
+    
+    // Add new error
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'field-error form-error-general';
+    errorDiv.textContent = message;
+    errorDiv.style.cssText = `
+      color: #e53e3e;
+      font-size: 0.875rem;
+      margin-top: 0.5rem;
+      padding: 0.5rem;
+      background: #fed7d7;
+      border-radius: 4px;
+    `;
+    
+    form.appendChild(errorDiv);
+  }
+
+  public destroy(): void {
+    if (this.boundHandleClick) {
+      this.element.removeEventListener('click', this.boundHandleClick);
+    }
+    if (this.boundHandleSubmit) {
+      this.element.removeEventListener('submit', this.boundHandleSubmit);
+    }
+    
+    this.element.remove();
+    this.backdrop.remove();
+  }
+}

--- a/web/components/src/schedules/schedule-service.ts
+++ b/web/components/src/schedules/schedule-service.ts
@@ -1,0 +1,128 @@
+import { ComponentConfig } from '../common/types.js';
+
+export interface TaskSchedule {
+  id: string;
+  family_id: string;
+  created_by: string;
+  title: string;
+  description: string;
+  task_type: 'todo' | 'chore' | 'appointment';
+  assigned_to?: string | null;
+  days_of_week: string[];
+  time_of_day?: string | null;
+  priority: number;
+  points: number;
+  active: boolean;
+  created_at: string;
+}
+
+export interface CreateScheduleRequest {
+  title: string;
+  description: string;
+  task_type: 'todo' | 'chore' | 'appointment';
+  assigned_to?: string | null;
+  days_of_week: string[];
+  time_of_day?: string | null;
+  priority: number;
+  points: number;
+  family_id: string;
+}
+
+export class ScheduleService {
+  private config: ComponentConfig;
+
+  constructor(config: ComponentConfig) {
+    this.config = config;
+  }
+
+  async listSchedules(familyId: string = 'fam1'): Promise<TaskSchedule[]> {
+    const response = await fetch(`${this.config.apiBaseUrl}/schedules?family_id=${familyId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch schedules: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async createSchedule(scheduleData: CreateScheduleRequest): Promise<TaskSchedule> {
+    const response = await fetch(`${this.config.apiBaseUrl}/schedules`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(scheduleData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `Failed to create schedule: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getSchedule(scheduleId: string): Promise<TaskSchedule> {
+    const response = await fetch(`${this.config.apiBaseUrl}/schedules/${scheduleId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch schedule: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async updateSchedule(scheduleId: string, updates: Partial<CreateScheduleRequest & { active?: boolean }>): Promise<TaskSchedule> {
+    const response = await fetch(`${this.config.apiBaseUrl}/schedules/${scheduleId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+      body: JSON.stringify(updates),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update schedule: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async deleteSchedule(scheduleId: string): Promise<void> {
+    const response = await fetch(`${this.config.apiBaseUrl}/schedules/${scheduleId}`, {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': this.config.csrfToken,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete schedule: ${response.statusText}`);
+    }
+  }
+
+  async toggleSchedule(scheduleId: string): Promise<{ active: boolean }> {
+    // Get current schedule to determine current active state
+    const currentSchedule = await this.getSchedule(scheduleId);
+    const newActiveState = !currentSchedule.active;
+
+    // Update the active field
+    await this.updateSchedule(scheduleId, { active: newActiveState });
+    
+    return { active: newActiveState };
+  }
+}

--- a/web/components/src/schedules/schedules-page.ts
+++ b/web/components/src/schedules/schedules-page.ts
@@ -1,0 +1,46 @@
+import { BasePage } from '../pages/base-page.js';
+import { ScheduleList } from './schedule-list.js';
+import { ComponentConfig } from '../common/types.js';
+
+/**
+ * SchedulesPage - Complete owner of all schedule-related functionality
+ * No more global component scanning - page creates and manages everything
+ */
+export class SchedulesPage extends BasePage {
+  private scheduleList?: ScheduleList;
+
+  constructor(container: HTMLElement, config: ComponentConfig) {
+    super(container, config, 'schedules');
+  }
+
+  async init(): Promise<void> {
+    // Create the basic page structure WITHOUT data-component attributes
+    // This prevents any global scanning conflicts
+    this.container.innerHTML = `
+      <div class="schedules-page">
+        <div class="schedules-container" id="main-schedule-container"></div>
+      </div>
+    `;
+
+    // Page directly creates and owns the ScheduleList - no global scanning
+    const scheduleContainer = this.container.querySelector('#main-schedule-container') as HTMLElement;
+    if (scheduleContainer) {
+      this.scheduleList = new ScheduleList(scheduleContainer, this.config);
+    }
+  }
+
+  async refresh(): Promise<void> {
+    if (this.scheduleList) {
+      // Reload schedules data
+      await this.scheduleList.refresh();
+    }
+  }
+
+  override destroy(): void {
+    if (this.scheduleList) {
+      this.scheduleList.destroy();
+      delete this.scheduleList;
+    }
+    super.destroy();
+  }
+}

--- a/web/components/src/tasks/__tests__/state-manager.test.ts
+++ b/web/components/src/tasks/__tests__/state-manager.test.ts
@@ -117,24 +117,6 @@ describe('StateManager', () => {
       expect(callback1).toHaveBeenCalledWith(expect.objectContaining({ loading: true }));
       expect(callback2).toHaveBeenCalledWith(expect.objectContaining({ loading: true }));
     });
-
-    it('should handle subscriber errors gracefully', () => {
-      const errorCallback = jest.fn(() => { throw new Error('Test error'); });
-      const goodCallback = jest.fn();
-      
-      stateManager.subscribe(errorCallback);
-      stateManager.subscribe(goodCallback);
-      
-      errorCallback.mockClear();
-      goodCallback.mockClear();
-      
-      // Should not throw, should call good callback despite error in first
-      expect(() => {
-        stateManager.setState({ loading: true });
-      }).not.toThrow();
-      
-      expect(goodCallback).toHaveBeenCalledWith(expect.objectContaining({ loading: true }));
-    });
   });
 
   describe('Convenience Methods', () => {

--- a/web/components/src/tasks/__tests__/task-drag-drop-manager.test.ts
+++ b/web/components/src/tasks/__tests__/task-drag-drop-manager.test.ts
@@ -203,31 +203,4 @@ describe('TaskDragDropManager', () => {
       expect(mockSortableConstructor).toHaveBeenCalledTimes(4); // 2 initial + 2 after destroy
     });
   });
-
-  describe('Error Handling', () => {
-    it('should handle errors in onTaskReorder callback gracefully', async () => {
-      const errorCallback = jest.fn().mockRejectedValue(new Error('Test error'));
-      const errorDragDropManager = new TaskDragDropManager(container, {
-        onTaskReorder: errorCallback
-      });
-
-      errorDragDropManager.setupSortable();
-
-      const sortableConfig = mockSortableConstructor.mock.calls[mockSortableConstructor.mock.calls.length - 1][1]; // Last call
-      const onEndCallback = sortableConfig.onEnd;
-
-      const mockEvent = {
-        item: container.querySelector('[data-task-container="task1"]'),
-        from: container.querySelector('[data-user-tasks="unassigned"]'),
-        to: container.querySelector('[data-user-tasks="user_user1"]'),
-        oldIndex: 0,
-        newIndex: 1
-      };
-
-      // Should not throw even if callback throws
-      await expect(onEndCallback(mockEvent)).resolves.toBeUndefined();
-      
-      expect(errorCallback).toHaveBeenCalledWith(mockEvent);
-    });
-  });
 });

--- a/web/components/src/tasks/__tests__/task-list-revert-bug.test.ts
+++ b/web/components/src/tasks/__tests__/task-list-revert-bug.test.ts
@@ -155,10 +155,6 @@ describe('TaskList Drag and Drop Revert Bug', () => {
 
       // Capture state before drag
       const stateBefore = stateManager.getState();
-      console.log('State before drag:', {
-        unassignedCount: stateBefore.tasks?.tasks_by_user['unassigned']?.tasks?.length,
-        userCount: stateBefore.tasks?.tasks_by_user['user_user1']?.tasks?.length
-      });
 
       // Execute the drag operation
       await onEndCallback(mockEvent);

--- a/web/components/src/tasks/state-manager.ts
+++ b/web/components/src/tasks/state-manager.ts
@@ -53,11 +53,7 @@ export class StateManager {
   subscribe(callback: (state: AppState) => void): () => void {
     this.subscribers.push(callback);
     
-    try {
-      callback(this.getState());
-    } catch (error) {
-      console.error('Error in state subscriber:', error);
-    }
+    callback(this.getState());
     
     // Return unsubscribe function
     return () => {
@@ -74,11 +70,7 @@ export class StateManager {
   private notifySubscribers(): void {
     const currentState = this.getState();
     this.subscribers.forEach(callback => {
-      try {
-        callback(currentState);
-      } catch (error) {
-        console.error('Error in state subscriber:', error);
-      }
+      callback(currentState);
     });
   }
 

--- a/web/components/src/tasks/task-drag-drop-manager.ts
+++ b/web/components/src/tasks/task-drag-drop-manager.ts
@@ -57,11 +57,7 @@ export class TaskDragDropManager {
       return;
     }
     
-    try {
-      await this.onTaskReorder(evt);
-    } catch (error) {
-      console.error('Error in task reorder callback:', error);
-    }
+    await this.onTaskReorder(evt);
   }
 
   destroy(): void {

--- a/web/components/src/tasks/task-list-renderer.ts
+++ b/web/components/src/tasks/task-list-renderer.ts
@@ -21,7 +21,7 @@ export class TaskListRenderer {
   }
 
   renderTaskList(data: TasksResponse): void {
-    this.container.innerHTML = `
+    const html = `
       <div class="task-list-header">
         <h2>Tasks for ${data.date}</h2>
         <button class="add-task-btn" data-action="add-task">
@@ -33,6 +33,7 @@ export class TaskListRenderer {
       </div>
       ${this.renderAddTaskModal(data)}
     `;
+    this.container.innerHTML = html;
   }
 
   private renderTaskColumns(data: TasksResponse): string {
@@ -63,7 +64,10 @@ export class TaskListRenderer {
   }
 
   private renderUserTasks(tasks: any[]): string {
-    return tasks.map(task => `<div data-task-container="${task.id}"></div>`).join('');
+    const html = tasks.map(task => {
+      return `<div data-task-container="${task.id}"></div>`;
+    }).join('');
+    return html;
   }
 
   private renderAddTaskModal(tasksData: TasksResponse): string {

--- a/web/components/src/tasks/task-list.ts
+++ b/web/components/src/tasks/task-list.ts
@@ -96,7 +96,9 @@ export class TaskList {
 
   private createTaskCards(): void {
     const state = stateManager.getState();
-    if (!state.tasks) return;
+    if (!state.tasks) {
+      return;
+    }
 
     // Clear existing cards
     this.taskCards.forEach(card => card.destroy());
@@ -108,14 +110,12 @@ export class TaskList {
       
       tasks.forEach(task => {
         const container = this.container.querySelector(`[data-task-container="${task.id}"]`) as HTMLElement;
-        if (container) {
-          const taskCard = new TaskCard(task, this.config, {
-            onTaskUpdate: this.handleTaskUpdate.bind(this),
-            onTaskDelete: this.handleTaskDelete.bind(this)
-          });
-          container.appendChild(taskCard.getElement());
-          this.taskCards.set(task.id, taskCard);
-        }
+        const taskCard = new TaskCard(task, this.config, {
+          onTaskUpdate: this.handleTaskUpdate.bind(this),
+          onTaskDelete: this.handleTaskDelete.bind(this)
+        });
+        container.appendChild(taskCard.getElement());
+        this.taskCards.set(task.id, taskCard);
       });
     });
   }
@@ -240,32 +240,7 @@ export class TaskList {
     }
   }
 
-  private getTaskCount(userKey: string): number {
-    return this.renderer.getTaskCount(userKey);
-  }
 
-  private setTaskCount(userKey: string, count: number): void {
-    this.renderer.updateTaskCount(userKey, count);
-  }
-
-  private updateTaskCounts(sourceUserKey: string | null, targetUserKey: string): void {
-    // Update task count for source user (decrease)
-    if (sourceUserKey) {
-      const currentCount = this.getTaskCount(sourceUserKey);
-      this.setTaskCount(sourceUserKey, Math.max(0, currentCount - 1));
-    }
-
-    // Update task count for target user (increase)
-    const currentCount = this.getTaskCount(targetUserKey);
-    this.setTaskCount(targetUserKey, currentCount + 1);
-  }
-
-  private updateTaskCardAssignment(taskId: string, newAssignedTo: string | null): void {
-    const taskCard = this.taskCards.get(taskId);
-    if (taskCard) {
-      taskCard.updateAssignment(newAssignedTo);
-    }
-  }
 
   private handleTaskUpdate(_task: Task): void {
     // Task was updated, we could update local state here if needed

--- a/web/components/src/tasks/tasks-page.ts
+++ b/web/components/src/tasks/tasks-page.ts
@@ -25,9 +25,7 @@ export class TasksPage extends BasePage {
 
       // Page directly creates and owns the TaskList - no global scanning
       const taskContainer = this.container.querySelector('#main-task-container') as HTMLElement;
-      if (taskContainer) {
-        this.taskList = new TaskList(taskContainer, this.config);
-      }
+      this.taskList = new TaskList(taskContainer, this.config);
 
     } catch (error) {
       this.showError('Failed to load tasks page');

--- a/web/static/js/index.css
+++ b/web/static/js/index.css
@@ -2,6 +2,7 @@
 @import './task-card.css';
 @import './task-list.css';
 @import './family-members.css';
+@import './schedules.css';
 
 /* Base styles for component integration */
 * {

--- a/web/static/js/schedules.css
+++ b/web/static/js/schedules.css
@@ -1,0 +1,425 @@
+/* Schedule List Styles */
+.schedule-list-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.schedule-header {
+  display: flex;
+  justify-content: between;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid #e1e5e9;
+}
+
+.schedule-header h1 {
+  margin: 0;
+  color: #2d3748;
+  font-size: 2rem;
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 20px;
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 60px 20px;
+  color: #718096;
+}
+
+.empty-state p {
+  margin: 10px 0;
+  font-size: 1.1rem;
+}
+
+.loading {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 40px;
+  color: #718096;
+}
+
+/* Schedule Card Styles */
+.schedule-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+  position: relative;
+}
+
+.schedule-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.schedule-card.active {
+  border-left: 4px solid #48bb78;
+}
+
+.schedule-card.inactive {
+  border-left: 4px solid #a0aec0;
+  opacity: 0.7;
+}
+
+.schedule-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.schedule-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #2d3748;
+  flex: 1;
+}
+
+.schedule-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.schedule-action-btn {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 16px;
+  transition: background-color 0.2s;
+}
+
+.schedule-action-btn:hover {
+  background: #f7fafc;
+}
+
+.schedule-description {
+  margin-bottom: 15px;
+  color: #4a5568;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.schedule-details {
+  margin-bottom: 15px;
+}
+
+.schedule-recurrence {
+  margin-bottom: 10px;
+}
+
+.schedule-days {
+  background: #edf2f7;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  color: #2d3748;
+  font-weight: 500;
+  display: inline-block;
+}
+
+.schedule-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.schedule-type {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.schedule-type.todo {
+  background: #bee3f8;
+  color: #2b6cb0;
+}
+
+.schedule-type.chore {
+  background: #c6f6d5;
+  color: #276749;
+}
+
+.schedule-type.appointment {
+  background: #fbb6ce;
+  color: #b83280;
+}
+
+.schedule-assignee {
+  color: #4a5568;
+  font-size: 0.9rem;
+}
+
+.schedule-points {
+  background: #fed7d7;
+  color: #c53030;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.schedule-status {
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;  /* Add this for consistent height */
+  display: inline-block;  /* Add this for better alignment */
+}
+
+.schedule-status.active {
+  background: #c6f6d5;
+  color: #276749;
+}
+
+.schedule-status.inactive {
+  background: #e2e8f0;
+  color: #718096;
+}
+
+/* Modal Styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 0;
+  max-width: 1200px;
+  width: 90vw;
+  min-width: 800px;
+  max-height: 95vh;
+  overflow-y: auto;
+  position: relative;
+  z-index: 1001;
+  margin: 20px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #2d3748;
+  font-size: 1.5rem;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #a0aec0;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-close:hover {
+  background: #f7fafc;
+  color: #4a5568;
+}
+
+.modal form {
+  padding: 24px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #e2e8f0;
+}
+
+/* Form Styles */
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.form-row-three {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 768px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+  
+  .form-row-three {
+    grid-template-columns: 1fr;
+  }
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #2d3748;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 16px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #3182ce;
+  box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.1);
+}
+
+.days-of-week {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.day-checkbox {
+  display: flex !important;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: normal !important;
+  margin-bottom: 0 !important;
+}
+
+.day-checkbox:hover {
+  background: #f7fafc;
+  border-color: #a0aec0;
+}
+
+.day-checkbox input[type="checkbox"] {
+  width: auto !important;
+  margin: 0;
+}
+
+.day-checkbox input[type="checkbox"]:checked + label,
+.day-checkbox:has(input[type="checkbox"]:checked) {
+  background: #3182ce;
+  color: white;
+  border-color: #3182ce;
+}
+
+/* Button Styles */
+.btn {
+  padding: 10px 16px;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+}
+
+.btn-primary {
+  background: #3182ce;
+  color: white;
+}
+
+.btn-primary:hover {
+  background: #2c5282;
+}
+
+.btn-secondary {
+  background: #e2e8f0;
+  color: #4a5568;
+}
+
+.btn-secondary:hover {
+  background: #cbd5e0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .schedule-list-container {
+    padding: 15px;
+  }
+  
+  .schedule-grid {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+  
+  .schedule-header {
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+  }
+  
+  .modal-content {
+    width: 98%;
+    margin: 5px;
+    max-height: 98vh;
+  }
+}

--- a/web/templates/app.html.tmpl
+++ b/web/templates/app.html.tmpl
@@ -22,6 +22,7 @@
                     </button>
                     <div class="dropdown-content">
                         <a href="/tasks" {{if eq .PageType "tasks"}}class="active"{{end}}>Daily Tasks</a>
+                        <a href="/schedules" {{if eq .PageType "schedules"}}class="active"{{end}}>Schedules</a>
                         <a href="/family/setup" {{if eq .PageType "family"}}class="active"{{end}}>Family Setup</a>
                     </div>
                 </div>


### PR DESCRIPTION
This diff introduces a new scheduled task system to the FamStack application.

Key Changes
A task_schedules table is added to store configurations for recurring tasks (e.g., "Take out the trash every Tuesday").

A task_queue table is created to handle the reliable generation of these tasks, using a worker pattern.

A new QueueWorker is implemented in Go that runs as a background process to process the items in the task_queue, ensuring tasks are created on the correct days.

The API is extended with new endpoints for creating, listing, retrieving, updating, and deleting scheduled tasks.

The front end is updated to support a new /schedules page, which will display and allow management of these recurring schedules.

The existing tasks table is altered to include a schedule_id column, linking generated tasks back to their parent schedule.

The core application startup logic is modified to start the new queue worker alongside the main web server.

In essence, this set of changes transforms the application from a simple to-do list into a more robust task management system that can handle recurring chores and appointments.

<img width="1420" height="403" alt="Screenshot 2025-09-12 at 7 20 07 PM" src="https://github.com/user-attachments/assets/a0497820-819f-4016-bed6-6520530fe4c4" />

<img width="1427" height="788" alt="Screenshot 2025-09-12 at 7 20 41 PM" src="https://github.com/user-attachments/assets/1c62553c-219d-4b37-b34c-de882f8b81bd" />

<img width="1424" height="442" alt="Screenshot 2025-09-12 at 7 20 23 PM" src="https://github.com/user-attachments/assets/2c73511d-8ae2-469c-8507-e622055194a1" />

<img width="1424" height="777" alt="Screenshot 2025-09-12 at 7 20 55 PM" src="https://github.com/user
-attachments/assets/b252ff5e-945d-4a1f-adca-025381557b35" />
